### PR TITLE
refactor(fluent_localization): Revert latest changes

### DIFF
--- a/packages/fluent_localization/fluent_localization/example/lib/main.dart
+++ b/packages/fluent_localization/fluent_localization/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:fluent_localization/fluent_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 
 void main() async {
   await Fluent.build([
@@ -27,14 +26,10 @@ class MainApp extends StatelessWidget {
       const Locale("en"),
     ];
     // Get localization delegates
-    final localizationDelegate = localizationApi.getDelegate(locales);
+    final localizationDelegates = localizationApi.getDelegates(locales);
 
     return MaterialApp(
-      localizationsDelegates: [
-        localizationDelegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
+      localizationsDelegates: localizationDelegates,
       supportedLocales: locales,
       home: Scaffold(
         body: Builder(

--- a/packages/fluent_localization/fluent_localization/example/pubspec.yaml
+++ b/packages/fluent_localization/fluent_localization/example/pubspec.yaml
@@ -9,8 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_localizations:
-    sdk: flutter
   fluent_localization: ^1.0.0
 
 dev_dependencies:

--- a/packages/fluent_localization/fluent_localization/lib/fluent_localization.dart
+++ b/packages/fluent_localization/fluent_localization/lib/fluent_localization.dart
@@ -1,5 +1,6 @@
 export 'package:fluent_localization_api/fluent_localization_api.dart';
 export 'package:fluent_sdk/fluent_sdk.dart';
 
+export 'src/fluent_localization_delegate.dart';
 export 'src/localization_extension.dart';
 export 'src/localization_module.dart';

--- a/packages/fluent_localization/fluent_localization/lib/src/api/localization_api_impl.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/api/localization_api_impl.dart
@@ -9,12 +9,14 @@ class LocalizationApiImpl extends LocalizationApi {
     List<Locale> locales, {
     Locale? defaultLocale,
     String? path,
+    bool shouldThrowExceptions = true,
   }) {
     return [
       FluentLocalizationDelegate(
         supportedLocales: locales,
         locale: defaultLocale,
         path: path ?? defaultPath,
+        shouldThrowExceptions: shouldThrowExceptions,
       ),
       GlobalMaterialLocalizations.delegate,
       GlobalCupertinoLocalizations.delegate,

--- a/packages/fluent_localization/fluent_localization/lib/src/api/localization_api_impl.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/api/localization_api_impl.dart
@@ -1,20 +1,25 @@
 import 'package:fluent_localization/fluent_localization.dart';
 import 'package:fluent_localization/src/fluent_localization.dart';
-import 'package:fluent_localization/src/fluent_localization_delegate.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 class LocalizationApiImpl extends LocalizationApi {
   @override
-  LocalizationsDelegate<dynamic> getDelegate(
+  List<LocalizationsDelegate<dynamic>> getDelegates(
     List<Locale> locales, {
     Locale? defaultLocale,
     String? path,
   }) {
-    return FluentLocalizationDelegate(
-      supportedLocales: locales,
-      locale: defaultLocale,
-      path: path ?? defaultPath,
-    );
+    return [
+      FluentLocalizationDelegate(
+        supportedLocales: locales,
+        locale: defaultLocale,
+        path: path ?? defaultPath,
+      ),
+      GlobalMaterialLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate
+    ];
   }
 
   @override

--- a/packages/fluent_localization/fluent_localization/lib/src/fluent_localization.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/fluent_localization.dart
@@ -25,8 +25,6 @@ class FluentLocalization {
   /// The localized strings.
   final Map<String, String> _strings = HashMap();
 
-  static bool testMode = false;
-
   /// Return the localization instance
   static FluentLocalization? of(BuildContext context) =>
       Localizations.of<FluentLocalization>(context, FluentLocalization);

--- a/packages/fluent_localization/fluent_localization/lib/src/fluent_localization.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/fluent_localization.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
@@ -26,24 +25,18 @@ class FluentLocalization {
   /// The localized strings.
   final Map<String, String> _strings = HashMap();
 
+  static bool testMode = false;
+
   /// Return the localization instance
   static FluentLocalization? of(BuildContext context) =>
       Localizations.of<FluentLocalization>(context, FluentLocalization);
 
   /// Loads the localized strings.
-  Future<bool> load() async {
-    try {
-      final filePath = '$path/$locale.json';
-      final data = await rootBundle.loadString(filePath);
-      (json.decode(data) as Map<String, dynamic>).forEach(_addStrings);
-      return true;
-    } catch (exception, stacktrace) {
-      if (kDebugMode) {
-        print(exception);
-        print(stacktrace);
-      }
-    }
-    return false;
+  Future<Map<String, String>> load() async {
+    final filePath = '$path/$locale.json';
+    final data = await rootBundle.loadString(filePath);
+    (json.decode(data) as Map<String, dynamic>).forEach(_addStrings);
+    return _strings;
   }
 
   /// Get the string associated with the specified key.

--- a/packages/fluent_localization/fluent_localization/lib/src/fluent_localization_delegate.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/fluent_localization_delegate.dart
@@ -9,6 +9,7 @@ class FluentLocalizationDelegate
     this.supportedLocales = const [Locale('en')],
     this.path = defaultPath,
     this.locale,
+    this.shouldThrowExceptions = true,
   });
 
   /// Contains all supported locales.
@@ -20,8 +21,8 @@ class FluentLocalizationDelegate
   /// Current locale
   final Locale? locale;
 
-  /// Silence exceptions or not
-  static bool shouldThrowExceptions = true;
+  /// Should throw or not exception when try to load asset resource
+  final bool shouldThrowExceptions;
 
   @override
   bool isSupported(Locale locale) {

--- a/packages/fluent_localization/fluent_localization/lib/src/fluent_localization_delegate.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/fluent_localization_delegate.dart
@@ -20,6 +20,9 @@ class FluentLocalizationDelegate
   /// Current locale
   final Locale? locale;
 
+  /// Silence exceptions or not
+  static bool shouldThrowExceptions = true;
+
   @override
   bool isSupported(Locale locale) {
     for (final supportedLocale in supportedLocales) {
@@ -37,7 +40,13 @@ class FluentLocalizationDelegate
       path: path,
     );
 
-    await localization.load();
+    try {
+      await localization.load();
+    } catch (e) {
+      if (shouldThrowExceptions) {
+        rethrow;
+      }
+    }
 
     return localization;
   }

--- a/packages/fluent_localization/fluent_localization/pubspec.yaml
+++ b/packages/fluent_localization/fluent_localization/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   fluent_sdk: ^0.2.0
   fluent_localization_api: ^1.0.0
 

--- a/packages/fluent_localization/fluent_localization/test/src/api/localization_api_impl_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/api/localization_api_impl_test.dart
@@ -1,5 +1,4 @@
 import 'package:fluent_localization/fluent_localization.dart';
-import 'package:fluent_localization/src/fluent_localization_delegate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,14 +14,15 @@ void main() {
 
   testWidgets('verify translate', (tester) async {
     final locales = [const Locale('en')];
-    final localizationDelegate = Fluent.get<LocalizationApi>().getDelegate(
+    final delegates = Fluent.get<LocalizationApi>().getDelegates(
       locales,
       path: 'test/assets/languages',
     );
+
     await tester.pumpWidget(
       MaterialApp(
         supportedLocales: locales,
-        localizationsDelegates: [localizationDelegate],
+        localizationsDelegates: delegates,
         home: Scaffold(
           body: Builder(
             builder: (context) {
@@ -43,24 +43,24 @@ void main() {
   test('verify getLocalizationDelegates', () async {
     final api = Fluent.get<LocalizationApi>();
 
-    final delegate = api.getDelegate([
+    final delegates = api.getDelegates([
       const Locale('es'),
       const Locale('en'),
     ]);
 
-    expect(delegate, isA<FluentLocalizationDelegate>());
+    expect(delegates.first, isA<FluentLocalizationDelegate>());
   });
 
   test('verify path', () async {
     final api = Fluent.get<LocalizationApi>();
     const pathLocation = 'assets/languages';
     const locale = Locale('es');
-    final delegate = api.getDelegate(
+    final delegates = api.getDelegates(
       [locale],
       path: 'assets/languages',
     );
 
-    final path = (delegate as FluentLocalizationDelegate).path;
+    final path = (delegates.first as FluentLocalizationDelegate).path;
 
     expect(path, pathLocation);
   });

--- a/packages/fluent_localization/fluent_localization/test/src/fluent_localization_delegate_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/fluent_localization_delegate_test.dart
@@ -39,4 +39,27 @@ void main() {
 
     expect(find.text('Hello Dev!'), findsOneWidget);
   });
+
+  test('verify shouldThrowExceptions should trhow error', () async {
+    const defaultLocale = Locale('en');
+
+    const delegate = FluentLocalizationDelegate(
+      locale: defaultLocale,
+    );
+
+    expect(delegate.load(defaultLocale), throwsA(isA<FlutterError>()));
+  });
+
+  test('verify shouldThrowExceptions should ignore error', () async {
+    FluentLocalizationDelegate.shouldThrowExceptions = false;
+
+    const defaultLocale = Locale('en');
+    const delegate = FluentLocalizationDelegate(
+      locale: defaultLocale,
+    );
+
+    final result = await delegate.load(defaultLocale);
+
+    expect(result, isA<FluentLocalization>());
+  });
 }

--- a/packages/fluent_localization/fluent_localization/test/src/fluent_localization_delegate_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/fluent_localization_delegate_test.dart
@@ -51,11 +51,10 @@ void main() {
   });
 
   test('verify shouldThrowExceptions should ignore error', () async {
-    FluentLocalizationDelegate.shouldThrowExceptions = false;
-
     const defaultLocale = Locale('en');
     const delegate = FluentLocalizationDelegate(
       locale: defaultLocale,
+      shouldThrowExceptions: false,
     );
 
     final result = await delegate.load(defaultLocale);

--- a/packages/fluent_localization/fluent_localization/test/src/fluent_localization_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/fluent_localization_test.dart
@@ -5,22 +5,31 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   setUp(WidgetsFlutterBinding.ensureInitialized);
 
-  test('verify fluent localization load return false', () async {
-    final localization = FluentLocalization();
-
-    final result = await localization.load();
-
-    expect(result, isFalse);
-  });
-
-  test('verify fluent localization load return true', () async {
+  test('verify fluent localization load', () async {
     final localization = FluentLocalization(
       path: 'test/assets/languages',
     );
 
     final result = await localization.load();
 
-    expect(result, isTrue);
+    expect(result, isNotEmpty);
+  });
+
+  test('verify fluent localization load throw FlutterError', () async {
+    final localization = FluentLocalization();
+
+    expect(localization.load(), throwsA(isA<FlutterError>()));
+  });
+
+  test('verify fluent localization load return map of strings', () async {
+    final localization = FluentLocalization(
+      path: 'test/assets/languages',
+    );
+
+    final result = await localization.load();
+
+    expect(result, isA<Map<String, String>>());
+    expect(result, isNotEmpty);
   });
 
   test('verify fluent localization get string with map return localized string',

--- a/packages/fluent_localization/fluent_localization_api/lib/src/localization_api.dart
+++ b/packages/fluent_localization/fluent_localization_api/lib/src/localization_api.dart
@@ -9,6 +9,7 @@ abstract class LocalizationApi {
     List<Locale> locales, {
     Locale? defaultLocale,
     String? path,
+    bool shouldThrowExceptions,
   });
 
   /// Translate a specific key through the build context

--- a/packages/fluent_localization/fluent_localization_api/lib/src/localization_api.dart
+++ b/packages/fluent_localization/fluent_localization_api/lib/src/localization_api.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 
 /// Interface defined to use the fluent localization functionalities
 abstract class LocalizationApi {
-  /// Get the localization delegate for supported locales
+  /// Get the localization delegates for supported locales
   /// on the default location, in order to change the default location
   /// use the path attribute to define it.
-  LocalizationsDelegate<dynamic> getDelegate(
+  List<LocalizationsDelegate<dynamic>> getDelegates(
     List<Locale> locales, {
     Locale? defaultLocale,
     String? path,


### PR DESCRIPTION
Added again `flutter_localizations` dependency and revert `getDelegate` API method signature
And added static flag that indicates if the delegate should or not throw exceptions

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
