### PR TITLE
feat(fluent_localization): Return empty map of string when locale file does not exists

### DIFF
--- a/packages/fluent_localization/fluent_localization/lib/src/fluent_localization.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/fluent_localization.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -32,8 +33,13 @@ class FluentLocalization {
   /// Loads the localized strings.
   Future<Map<String, String>> load() async {
     final filePath = '$path/$locale.json';
-    final data = await rootBundle.loadString(filePath);
-    (json.decode(data) as Map<String, dynamic>).forEach(_addStrings);
+    final fileExists = File(filePath).existsSync();
+
+    if (fileExists) {
+      final data = await rootBundle.loadString(filePath);
+      (json.decode(data) as Map<String, dynamic>).forEach(_addStrings);
+    }
+
     return _strings;
   }
 

--- a/packages/fluent_localization/fluent_localization/test/src/fluent_localization_delegate_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/fluent_localization_delegate_test.dart
@@ -40,13 +40,30 @@ void main() {
     expect(find.text('Hello Dev!'), findsOneWidget);
   });
 
-  test('verify shouldThrowExceptions should throw error', () async {
+  test(
+      '''verify fluent localization delegate return map of strings when locale does not exists''',
+      () async {
     const defaultLocale = Locale('en');
 
     const delegate = FluentLocalizationDelegate(
       locale: defaultLocale,
     );
 
-    expect(delegate.load(defaultLocale), throwsA(isA<FlutterError>()));
+    final result = await delegate.load(defaultLocale);
+
+    expect(result, isA<FluentLocalization>());
+  });
+
+  test(
+      '''verify fluent localization throws format exception when file is malformed''',
+      () async {
+    const defaultLocale = Locale('es');
+
+    const delegate = FluentLocalizationDelegate(
+      locale: defaultLocale,
+      path: 'test/assets/languages',
+    );
+
+    expect(delegate.load(defaultLocale), throwsA(isA<FormatException>()));
   });
 }

--- a/packages/fluent_localization/fluent_localization/test/src/fluent_localization_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/fluent_localization_test.dart
@@ -15,10 +15,16 @@ void main() {
     expect(result, isNotEmpty);
   });
 
-  test('verify fluent localization load throw FlutterError', () async {
-    final localization = FluentLocalization();
+  test(
+      '''verify fluent localization load return empty map of strings when file does not exists''',
+      () async {
+    final localization = FluentLocalization(
+      path: 'path/does/not/exists',
+    );
 
-    expect(localization.load(), throwsA(isA<FlutterError>()));
+    final result = await localization.load();
+
+    expect(result, isEmpty);
   });
 
   test('verify fluent localization load return map of strings', () async {


### PR DESCRIPTION
Return empty map of string when locale file does not exist

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
