### PR TITLE
style(environment): allow customization of text style and fix directionality leakage in EnvironmentBanner

### DIFF
--- a/packages/fluent_environment/fluent_environment/example/lib/main.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/main.dart
@@ -21,7 +21,14 @@ class MainApp extends StatelessWidget {
 
     return MaterialApp(
       title: 'Fluent Environment Example',
-      builder: (context, child) => EnvironmentBanner(child: child!),
+      builder: (context, child) => EnvironmentBanner(
+        textStyle: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+        child: child!,
+      ),
       home: Scaffold(
         body: Center(child: Text("Environment: ${environment.name}")),
       ),

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -16,10 +16,12 @@ class EnvironmentBanner extends StatelessWidget {
   /// The [environment] can be optionally provided; if null, it defaults to
   /// the environment retrieved from `Fluent.get<EnvironmentApi>()`.
   /// The [location] determines where the banner is displayed.
+  /// The [textStyle] can be used to customize the banner's text.
   const EnvironmentBanner({
     required this.child,
     this.environment,
     this.location = BannerLocation.bottomEnd,
+    this.textStyle,
     super.key,
   });
 
@@ -37,6 +39,9 @@ class EnvironmentBanner extends StatelessWidget {
   /// The location of the banner.
   final BannerLocation location;
 
+  /// The text style of the banner.
+  final TextStyle? textStyle;
+
   @override
   Widget build(BuildContext context) {
     final env = environment ?? Fluent.get<EnvironmentApi>().environment;
@@ -48,19 +53,19 @@ class EnvironmentBanner extends StatelessWidget {
     return Semantics(
       label: 'Environment: ${env.name}',
       container: true,
-      child: Directionality(
+      child: Banner(
+        color: env.color,
+        message: env.name,
+        location: location,
         textDirection: TextDirection.ltr,
-        child: Banner(
-          color: env.color,
-          message: env.name,
-          location: location,
-          textStyle: const TextStyle(
-            fontSize: 10.2,
-            fontWeight: FontWeight.w900,
-            height: 1,
-          ),
-          child: child,
-        ),
+        layoutDirection: TextDirection.ltr,
+        textStyle: textStyle ??
+            const TextStyle(
+              fontSize: 10.2,
+              fontWeight: FontWeight.w900,
+              height: 1,
+            ),
+        child: child,
       ),
     );
   }

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -59,7 +59,8 @@ class EnvironmentBanner extends StatelessWidget {
         location: location,
         textDirection: TextDirection.ltr,
         layoutDirection: TextDirection.ltr,
-        textStyle: textStyle ??
+        textStyle:
+            textStyle ??
             const TextStyle(
               fontSize: 10.2,
               fontWeight: FontWeight.w900,

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -101,4 +101,98 @@ void main() {
     expect(find.byType(Banner), findsNothing);
     expect(find.text('Content'), findsOneWidget);
   });
+
+  testWidgets('should use default text style when none is provided', (
+    tester,
+  ) async {
+    // Arrange
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: EnvironmentBanner(
+            environment: mockEnv,
+            child: const Text('Content'),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    final bannerWidget = tester.widget<Banner>(find.byType(Banner));
+    expect(bannerWidget.textStyle.fontSize, 10.2);
+    expect(bannerWidget.textStyle.fontWeight, FontWeight.w900);
+    expect(bannerWidget.textStyle.height, 1);
+  });
+
+  testWidgets('should NOT leak directionality to child', (tester) async {
+    // Arrange
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: EnvironmentBanner(
+              environment: mockEnv,
+              child: Builder(
+                builder: (context) {
+                  return Text(Directionality.of(context).name);
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    // If the bug exists, it will find 'ltr' because EnvironmentBanner
+    // wraps the child in Directionality(textDirection: TextDirection.ltr).
+    // We expect it to be 'rtl'.
+    expect(find.text('rtl'), findsOneWidget);
+  });
+
+  testWidgets('should use custom text style when provided', (tester) async {
+    // Arrange
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    const customStyle = TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.bold,
+      color: Colors.blue,
+    );
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: EnvironmentBanner(
+            environment: mockEnv,
+            textStyle: customStyle,
+            child: const Text('Content'),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    final bannerWidget = tester.widget<Banner>(find.byType(Banner));
+    expect(bannerWidget.textStyle.fontSize, 20);
+    expect(bannerWidget.textStyle.fontWeight, FontWeight.bold);
+    expect(bannerWidget.textStyle.color, Colors.blue);
+  });
 }


### PR DESCRIPTION
This PR enhances the `EnvironmentBanner` widget by adding an optional `textStyle` parameter, allowing developers to customize the appearance of the environment label to match their app's theme.

Additionally, it fixes a bug where the `EnvironmentBanner` was forcing `TextDirection.ltr` on its child widget by using a `Directionality` wrapper. The fix involves passing the directions directly to the `Banner` widget, ensuring that the banner itself maintains its layout while allowing the child widget to inherit the correct directionality from the parent. This improvement makes the toolkit more accessible and compatible with RTL (Right-to-Left) languages.

Changes:
- Added `textStyle` parameter to `EnvironmentBanner`.
- Refactored `build` method to avoid `Directionality` leakage.
- Updated example app and tests to reflect these changes.

---
*PR created automatically by Jules for task [17940885303467987658](https://jules.google.com/task/17940885303467987658) started by @aosorio-avilez*