### PR TITLE
perf(networking): optimize logging in networking interceptor

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:fluent_logger_api/fluent_logger_api.dart';
-import 'package:fluent_sdk/fluent_sdk.dart';
 
 /// A secure networking interceptor that logs requests and responses.
 ///
@@ -10,7 +9,9 @@ import 'package:fluent_sdk/fluent_sdk.dart';
 /// [LoggerApi] for output.
 class NetworkingLogInterceptor extends Interceptor {
   /// Creates a [NetworkingLogInterceptor].
-  const NetworkingLogInterceptor();
+  const NetworkingLogInterceptor([this._logger]);
+
+  final LoggerApi? _logger;
 
   static const _sensitiveHeaders = {
     'authorization',
@@ -144,27 +145,35 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   void _log(String message) {
+    final logger = _logger;
+
+    if (logger == null) return;
+
     for (final line in message.split('\n')) {
       try {
-        Fluent.get<LoggerApi>().logInfo(line);
+        logger.logInfo(line);
       } on Object {
-        // Silently ignore if LoggerApi is not registered
+        // Silently ignore
       }
     }
   }
 
   void _logError(String message, {StackTrace? stackTrace}) {
+    final logger = _logger;
+
+    if (logger == null) return;
+
     final lines = message.split('\n');
     for (var i = 0; i < lines.length; i++) {
       final line = lines[i];
       final isLastLine = i == lines.length - 1;
       try {
-        Fluent.get<LoggerApi>().logError(
+        logger.logError(
           line,
           stackTrace: isLastLine ? stackTrace : null,
         );
       } on Object {
-        // Silently ignore if LoggerApi is not registered
+        // Silently ignore
       }
     }
   }

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:fluent_logger_api/fluent_logger_api.dart';
 import 'package:fluent_networking/fluent_networking.dart';
 import 'package:fluent_networking/src/interceptors/networking_log_interceptor.dart';
 import 'package:fluent_networking/src/networking_api_impl.dart';
@@ -13,7 +14,7 @@ class NetworkingModule extends FluentModule {
   @override
   void onCreate(Registry registry) {
     registry
-      ..registerLazySingleton<Dio>((_) {
+      ..registerLazySingleton<Dio>((it) {
         final dio = Dio(
           BaseOptions(
             baseUrl: config.baseUrl,
@@ -28,7 +29,13 @@ class NetworkingModule extends FluentModule {
 
         if (config.enableLog &&
             !const bool.fromEnvironment('dart.vm.product')) {
-          dio.interceptors.add(const NetworkingLogInterceptor());
+          LoggerApi? logger;
+          try {
+            logger = it<LoggerApi>();
+          } on Object {
+            // Silently ignore if LoggerApi is not registered
+          }
+          dio.interceptors.add(NetworkingLogInterceptor(logger));
         }
 
         return dio;

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
@@ -18,16 +18,16 @@ class MockErrorInterceptorHandler extends Mock
 
 void main() {
   late MockLoggerApi mockLoggerApi;
+  late NetworkingLogInterceptor interceptor;
 
   setUp(() async {
     await Fluent.reset();
     mockLoggerApi = MockLoggerApi();
     Fluent.mock<LoggerApi>(mockLoggerApi);
+    interceptor = NetworkingLogInterceptor(mockLoggerApi);
   });
 
   group('NetworkingLogInterceptor', () {
-    const interceptor = NetworkingLogInterceptor();
-
     test('onRequest should log request and sanitize authorization header', () {
       final options = RequestOptions(
         path: 'https://api.example.com',
@@ -206,14 +206,13 @@ void main() {
       verify(() => handler.next(err)).called(1);
     });
 
-    test('should handle gracefully if LoggerApi is not registered', () async {
-      // Unregister LoggerApi
-      await Fluent.reset();
+    test('should handle gracefully if LoggerApi is null', () async {
+      const interceptor = NetworkingLogInterceptor();
 
       final options = RequestOptions(path: 'https://api.example.com');
       final handler = MockRequestInterceptorHandler();
 
-      // Should not throw even if LoggerApi is missing because of the try-catch
+      // Should not throw even if LoggerApi is missing
       expect(() => interceptor.onRequest(options, handler), returnsNormally);
     });
   });


### PR DESCRIPTION
This PR optimizes the performance of the networking logging by using constructor injection for the LoggerApi in NetworkingLogInterceptor. 

Previously, the interceptor called `Fluent.get<LoggerApi>()` for every single line of output during request, response, and error logging. For large JSON payloads, this resulted in hundreds of redundant service locator lookups and potential exception handling overhead.

By injecting the LoggerApi once during the initialization of the NetworkingModule, we've eliminated this O(N) lookup overhead, making the toolkit more efficient when logging is enabled.

Tests and static analysis have been verified across the monorepo.

---
*PR created automatically by Jules for task [11100031325275772374](https://jules.google.com/task/11100031325275772374) started by @aosorio-avilez*