### PR TITLE
feat(networking): expose Options type from dio

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/fluent_networking.dart
+++ b/packages/fluent_networking/fluent_networking/lib/fluent_networking.dart
@@ -1,5 +1,6 @@
 export 'package:dio/dio.dart'
     show
+        Options,
         RequestInterceptorHandler,
         RequestOptions,
         Response,


### PR DESCRIPTION
This PR exposes the `Options` class from the `dio` package within `fluent_networking`. 

Previously, developers using `fluent_networking` who needed to define custom request configurations (such as headers or timeouts at the request level) had to import the `dio` package directly into their feature modules. By adding `Options` to the toolkit's public exports, we simplify the development experience and maintain better abstraction from third-party dependencies.

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
