### PR TITLE
style(environment): allow customization of text style and fix directionality in EnvironmentBanner

### DIFF
--- a/packages/fluent_environment/fluent_environment/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment/CHANGELOG.md
@@ -51,3 +51,5 @@
 * Enable const constructors for EnvironmentModule
 * Show/hide environment banner validation added
 * Use registerLazySingleton for environment optimization
+* Added `textStyle` parameter to `EnvironmentBanner` for better customization
+* Fixed `Directionality` leakage in `EnvironmentBanner` to prevent affecting child layouts

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -16,10 +16,12 @@ class EnvironmentBanner extends StatelessWidget {
   /// The [environment] can be optionally provided; if null, it defaults to
   /// the environment retrieved from `Fluent.get<EnvironmentApi>()`.
   /// The [location] determines where the banner is displayed.
+  /// The [textStyle] can be optionally provided to customize the banner's text.
   const EnvironmentBanner({
     required this.child,
     this.environment,
     this.location = BannerLocation.bottomEnd,
+    this.textStyle,
     super.key,
   });
 
@@ -37,6 +39,9 @@ class EnvironmentBanner extends StatelessWidget {
   /// The location of the banner.
   final BannerLocation location;
 
+  /// The style of the banner's text.
+  final TextStyle? textStyle;
+
   @override
   Widget build(BuildContext context) {
     final env = environment ?? Fluent.get<EnvironmentApi>().environment;
@@ -48,19 +53,20 @@ class EnvironmentBanner extends StatelessWidget {
     return Semantics(
       label: 'Environment: ${env.name}',
       container: true,
-      child: Directionality(
+      child: Banner(
+        color: env.color,
+        message: env.name,
+        location: location,
         textDirection: TextDirection.ltr,
-        child: Banner(
-          color: env.color,
-          message: env.name,
-          location: location,
-          textStyle: const TextStyle(
-            fontSize: 10.2,
-            fontWeight: FontWeight.w900,
-            height: 1,
-          ),
-          child: child,
-        ),
+        layoutDirection: TextDirection.ltr,
+        textStyle:
+            textStyle ??
+            const TextStyle(
+              fontSize: 10.2,
+              fontWeight: FontWeight.w900,
+              height: 1,
+            ),
+        child: child,
       ),
     );
   }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -78,6 +78,63 @@ void main() {
     expect(bannerWidget.location, BannerLocation.topStart);
   });
 
+  testWidgets('should apply custom text style', (tester) async {
+    // Arrange
+    const customStyle = TextStyle(fontSize: 20, color: Colors.blue);
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: EnvironmentBanner(
+            environment: mockEnv,
+            textStyle: customStyle,
+            child: const Text('Content'),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    final bannerFinder = find.byType(Banner);
+    final bannerWidget = tester.widget<Banner>(bannerFinder);
+    expect(bannerWidget.textStyle, customStyle);
+  });
+
+  testWidgets('should NOT leak Directionality to child', (tester) async {
+    // Arrange
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: EnvironmentBanner(
+              environment: mockEnv,
+              child: Builder(
+                builder: (context) {
+                  return Text(Directionality.of(context).toString());
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    expect(find.text('TextDirection.rtl'), findsOneWidget);
+  });
+
   testWidgets('should NOT display banner when environment IS prod', (
     tester,
   ) async {


### PR DESCRIPTION
This PR introduces two micro-improvements to the `EnvironmentBanner` widget in the `fluent_environment` package:

1.  **Text Style Customization**: Added an optional `textStyle` parameter to the `EnvironmentBanner` constructor. This allows developers to customize the appearance of the environment name (e.g., changing font size, weight, or color) instead of relying on hardcoded defaults.
2.  **Directionality Fix**: Fixed a "directionality leakage" issue where the widget previously wrapped its entire child subtree in an LTR `Directionality` widget. This was causing problems for applications using Right-to-Left (RTL) layouts. The fix ensures that the banner's directionality is applied only to the banner itself, while the child content correctly inherits the ambient directionality from the rest of the app.

These changes make the `EnvironmentBanner` more flexible and accessible for a wider range of application designs and locales.

---
*PR created automatically by Jules for task [9206061438526206858](https://jules.google.com/task/9206061438526206858) started by @aosorio-avilez*