### PR TITLE
chore(release): fluent_networking v0.5.3 and fluent_networking_api v0.3.0

### DIFF
--- a/packages/fluent_networking/fluent_networking/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking/CHANGELOG.md
@@ -1,47 +1,20 @@
-## 0.0.1
+## 0.5.3
 
-* Initial version.
+* **FEAT**: Add customizable retry interceptor and test coverage.
+* **FIX**: Implement secure logging with body sanitization and configurable redaction.
+* **FIX**: Add missing dio exports.
+* **PERF**: Optimize logging in networking interceptor.
 
-## 0.0.2
+## 0.5.2
 
-* Version of `fluent_networking_api` was updated to v0.0.3
+* **FIX**: Implement a secure `NetworkingLogInterceptor` that redacts sensitive headers (Authorization, Cookie, Set-Cookie).
+* **FEAT**: Expose `Options` type from `dio` in the public barrel file.
+* **REFACTOR**: Integrate `LoggerApi` for internal package logging instead of `print`/`debugPrint`.
+* **CHORE**: Replace `pretty_dio_logger` dependency with `fluent_logger_api`.
 
-## 0.0.2+1
+## 0.5.1
 
-* Removed sdk flutter dependency
-* Replace `flutter_test` to `test` dependency
-
-## 0.0.3
-
-* Dependency `fluent_sdk` was added
-* Version of `fluent_networking_api` was updated to v0.0.4
-
-## 0.0.4
-
-* Version of `fluent_sdk` was updated to v0.2.0
-
-## 0.1.0
-
-* Upgrade package to flutter version v3.35
-
-## 0.2.0
-
-> **BREAKING CHANGE:** This version migrates response handling to Sealed Classes.
-
-* **FIX:** Interceptors provided in config are now correctly added to Dio.
-* **REFACTOR:** `NetworkingConfig` now requires `enableLog` boolean instead of auto-detecting debug mode.
-* **FEAT:** Defined `ResponseResult` as a `sealed class` for exhaustiveness checking.
-* **REFACTOR:** Renamed/Removed old result classes (`Succeeded`, `Failed`, `Error`) in favor of `Success` and `Failure`.
-
-## 0.3.0
-
-* Upgrade fluent_sdk version to v0.4.0
-
-## 0.4.0
-
-* BREAKING CHANGE: Updated `fluent_sdk` dependency to `^0.5.0`
-* REFACTOR: Renamed `build` method to `onCreate` in `NetworkingModule`
-* CHORE: Recreated example platforms and updated READMEs.
+* **FIX**: Export common dio types and cleanup test imports.
 
 ## 0.5.0
 
@@ -52,6 +25,47 @@
 * Upgrade `dio` dependency to `^5.9.1`
 * Upgrade `equatable` dependency to `^2.0.8`
 
-## 0.5.1
+## 0.4.0
 
-* **FIX**: Export common dio types and cleanup test imports.
+* BREAKING CHANGE: Updated `fluent_sdk` dependency to `^0.5.0`
+* REFACTOR: Renamed `build` method to `onCreate` in `NetworkingModule`
+* CHORE: Recreated example platforms and updated READMEs.
+
+## 0.3.0
+
+* Upgrade fluent_sdk version to v0.4.0
+
+## 0.2.0
+
+> **BREAKING CHANGE:** This version migrates response handling to Sealed Classes.
+
+* **FIX:** Interceptors provided in config are now correctly added to Dio.
+* **REFACTOR:** `NetworkingConfig` now requires `enableLog` boolean instead of auto-detecting debug mode.
+* **FEAT:** Defined `ResponseResult` as a `sealed class` for exhaustiveness checking.
+* **REFACTOR:** Renamed/Removed old result classes (`Succeeded`, `Failed`, `Error`) in favor of `Success` and `Failure`.
+
+## 0.1.0
+
+* Upgrade package to flutter version v3.35
+
+## 0.0.4
+
+* Version of `fluent_sdk` was updated to v0.2.0
+
+## 0.0.3
+
+* Dependency `fluent_sdk` was added
+* Version of `fluent_networking_api` was updated to v0.0.4
+
+## 0.0.2+1
+
+* Removed sdk flutter dependency
+* Replace `flutter_test` to `test` dependency
+
+## 0.0.2
+
+* Version of `fluent_networking_api` was updated to v0.0.3
+
+## 0.0.1
+
+* Initial version.

--- a/packages/fluent_networking/fluent_networking/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_networking
 description: Package that provides a simple way to make http requests
-version: 0.5.1
+version: 0.5.3
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_networking/fluent_networking
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   fluent_sdk: ^0.6.0
-  fluent_networking_api: ^0.2.0
+  fluent_networking_api: ^0.3.0
   fluent_logger_api: ^0.0.4
   dio: ^5.9.1
   equatable: ^2.0.8

--- a/packages/fluent_networking/fluent_networking_api/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking_api/CHANGELOG.md
@@ -1,23 +1,10 @@
-## 0.0.1
+## 0.3.0
 
-* Initial version.
+* **FEAT**: Add customizable retry interceptor and configuration.
 
-## 0.0.2
+## 0.2.0
 
-* Version of `fluent_sdk` was updated to v0.1.1
-* Public APIs was documented
-
-## 0.0.3
-
-* Removed flutter dependency
-
-## 0.0.3+1
-
-* Removed sdk flutter dependency
-
-## 0.0.4
-
-* Dependency `fluent_sdk` was removed
+* Update version to 0.2.0
 
 ## 0.1.0
 
@@ -26,6 +13,23 @@
 * **FEAT:** Defined `ResponseResult` as a `sealed class` for exhaustiveness checking.
 * **REFACTOR:** Renamed/Removed old result classes (`Succeeded`, `Failed`, `Error`) in favor of `Success` and `Failure`.
 
-## 0.2.0
+## 0.0.4
 
-* Update version to 0.2.0
+* Dependency `fluent_sdk` was removed
+
+## 0.0.3+1
+
+* Removed sdk flutter dependency
+
+## 0.0.3
+
+* Removed flutter dependency
+
+## 0.0.2
+
+* Version of `fluent_sdk` was updated to v0.1.1
+* Public APIs was documented
+
+## 0.0.1
+
+* Initial version.

--- a/packages/fluent_networking/fluent_networking_api/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_networking_api
 description: A common interface for the fluent_networking package.
-version: 0.2.0
+version: 0.3.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_networking/fluent_networking_api
 


### PR DESCRIPTION
This PR prepares the release of `fluent_networking` v0.5.3 and `fluent_networking_api` v0.3.0. The main objective is to provide a more resilient and secure networking layer by introducing a customizable retry mechanism and enhancing the security of our logging interceptors.

Beyond the new features, this release performs essential housekeeping by restoring the v0.5.2 history in the CHANGELOG (which was lost during a merge regression) and standardizing the CHANGELOG format to descending order (newest first).

**Main Changes:**
- **Networking Resilience**: Introduced a customizable Retry Interceptor that automatically handles timeouts and server errors (5xx).
- **Secure Logging**: Enhanced logging with body sanitization and configurable redaction for sensitive information.
- **Versioning**: Bumped `fluent_networking` to `0.5.3` and `fluent_networking_api` to `0.3.0`.
- **Performance**: Optimized logging loops and dependency resolution within interceptors.

List which issues are fixed by this PR:
- Fixes the version regression and CHANGELOG mess introduced in previous merges.
- Consolidates changes from PRs #108, #107, #115, and #106.

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [x] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
