### PR TITLE
feat: Improve accessibility and allow text style customization in EnvironmentBanner

### DIFF
--- a/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
@@ -22,6 +22,7 @@ class EnvironmentApiImpl extends EnvironmentApi {
     return showModalBottomSheet<void>(
       context: effectiveContext,
       isScrollControlled: true,
+      showDragHandle: true,
       builder: (context) {
         return EnvironmentInspector(
           environment: _environment,

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -75,8 +75,8 @@ class EnvironmentBanner extends StatelessWidget {
       color: env.color,
       message: env.name,
       location: location,
-      textDirection: TextDirection.ltr,
-      layoutDirection: TextDirection.ltr,
+      textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+      layoutDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
       textStyle:
           textStyle ??
           const TextStyle(

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -26,6 +26,7 @@ class EnvironmentBanner extends StatelessWidget {
     this.configValuesLabel,
     this.noValuesLabel,
     this.navigatorKey,
+    this.textStyle,
     super.key,
   });
 
@@ -58,6 +59,9 @@ class EnvironmentBanner extends StatelessWidget {
   /// context that is not a descendant of a [Navigator].
   final GlobalKey<NavigatorState>? navigatorKey;
 
+  /// The text style of the banner.
+  final TextStyle? textStyle;
+
   @override
   Widget build(BuildContext context) {
     final envApi = Fluent.get<EnvironmentApi>();
@@ -71,11 +75,15 @@ class EnvironmentBanner extends StatelessWidget {
       color: env.color,
       message: env.name,
       location: location,
-      textStyle: const TextStyle(
-        fontSize: 10.2,
-        fontWeight: FontWeight.w900,
-        height: 1,
-      ),
+      textDirection: TextDirection.ltr,
+      layoutDirection: TextDirection.ltr,
+      textStyle:
+          textStyle ??
+          const TextStyle(
+            fontSize: 10.2,
+            fontWeight: FontWeight.w900,
+            height: 1,
+          ),
       child: child,
     );
 
@@ -112,10 +120,7 @@ class EnvironmentBanner extends StatelessWidget {
     return Semantics(
       label: 'Environment: ${env.name}',
       container: true,
-      child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: content,
-      ),
+      child: content,
     );
   }
 

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -131,7 +131,7 @@ class EnvironmentInspector extends StatelessWidget {
                           if (value != null)
                             IconButton(
                               icon: const Icon(Icons.copy_all, size: 20),
-                              tooltip: 'Copy to clipboard',
+                              tooltip: 'Copy "$key" to clipboard',
                               onPressed: () {
                                 unawaited(
                                   Clipboard.setData(

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -208,4 +208,32 @@ void main() {
     // Assert
     expect(capturedDirection, TextDirection.rtl);
   });
+
+  testWidgets('should respect ambient directionality', (tester) async {
+    // Arrange
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: EnvironmentBanner(
+              environment: mockEnv,
+              child: const Text('Content'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    final bannerWidget = tester.widget<Banner>(find.byType(Banner));
+    expect(bannerWidget.textDirection, TextDirection.rtl);
+    expect(bannerWidget.layoutDirection, TextDirection.rtl);
+  });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -149,4 +149,63 @@ void main() {
       verify(() => mockEnvApi.showInspector(any())).called(1);
     },
   );
+
+  testWidgets('should apply custom text style', (tester) async {
+    // Arrange
+    const textStyle = TextStyle(fontSize: 20, color: Colors.blue);
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: EnvironmentBanner(
+            environment: mockEnv,
+            textStyle: textStyle,
+            child: const Text('Content'),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    final bannerWidget = tester.widget<Banner>(find.byType(Banner));
+    expect(bannerWidget.textStyle, textStyle);
+  });
+
+  testWidgets('should NOT override child directionality', (tester) async {
+    // Arrange
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    TextDirection? capturedDirection;
+
+    // Act
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
+            body: EnvironmentBanner(
+              environment: mockEnv,
+              child: Builder(
+                builder: (context) {
+                  capturedDirection = Directionality.of(context);
+                  return const Text('Content');
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Assert
+    expect(capturedDirection, TextDirection.rtl);
+  });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -91,5 +91,8 @@ void main() {
     // Assert
     expect(find.byType(SnackBar), findsOneWidget);
     expect(find.text('Copied "key" to clipboard'), findsOneWidget);
+
+    final iconButton = tester.widget<IconButton>(find.byType(IconButton));
+    expect(iconButton.tooltip, 'Copy "key" to clipboard');
   });
 }


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the `fluent_environment` package:

- **`EnvironmentBanner` Customization:** Added a `textStyle` parameter to allow developers to customize the appearance of the environment banner.
- **Directionality Fix:** Refactored `EnvironmentBanner` to prevent it from forcing LTR directionality on its child widget, which previously could break RTL layouts.
- **Improved Inspector UX:** Added a drag handle to the environment inspector bottom sheet, providing a standard Material 3 visual cue.
- **Better Accessibility:** Updated the copy button tooltip in the inspector to be more descriptive (e.g., 'Copy "api_key" to clipboard'), making it clearer for all users, especially those using screen readers.

These changes were verified through automated tests and visual inspection.

---
*PR created automatically by Jules for task [8417499702054456187](https://jules.google.com/task/8417499702054456187) started by @aosorio-avilez*