### PR TITLE
fix(environment): redact sensitive keys in environment inspector

### DIFF
--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -101,7 +101,13 @@ class EnvironmentInspector extends StatelessWidget {
                   itemBuilder: (context, index) {
                     final key = environment.values.keys.elementAt(index);
                     final value = environment.values[key];
-                    final stringValue = value ?? 'N/A';
+                    final isSensitive = environment.sensitiveKeys.any(
+                      (sensitiveKey) =>
+                          sensitiveKey.toLowerCase() == key.toLowerCase(),
+                    );
+                    final stringValue = isSensitive
+                        ? '***REDACTED***'
+                        : (value ?? 'N/A');
 
                     return Padding(
                       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -128,7 +134,7 @@ class EnvironmentInspector extends StatelessWidget {
                               ],
                             ),
                           ),
-                          if (value != null)
+                          if (value != null && !isSensitive)
                             IconButton(
                               icon: const Icon(Icons.copy_all, size: 20),
                               tooltip: 'Copy to clipboard',

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -30,6 +30,9 @@ class EnvironmentInspector extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final sensitiveKeys = environment.sensitiveKeys
+        .map((e) => e.toLowerCase())
+        .toSet();
 
     return SafeArea(
       child: Container(
@@ -101,9 +104,8 @@ class EnvironmentInspector extends StatelessWidget {
                   itemBuilder: (context, index) {
                     final key = environment.values.keys.elementAt(index);
                     final value = environment.values[key];
-                    final isSensitive = environment.sensitiveKeys.any(
-                      (sensitiveKey) =>
-                          sensitiveKey.toLowerCase() == key.toLowerCase(),
+                    final isSensitive = sensitiveKeys.contains(
+                      key.toLowerCase(),
                     );
                     final stringValue = isSensitive
                         ? '***REDACTED***'

--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -29,6 +29,7 @@ void main() {
       when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
       when(() => mockEnv.color).thenReturn(Colors.red);
       when(() => mockEnv.values).thenReturn({});
+      when(() => mockEnv.sensitiveKeys).thenReturn({});
 
       final api = EnvironmentApiImpl(mockEnv);
 
@@ -65,6 +66,7 @@ void main() {
     when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
     when(() => mockEnv.color).thenReturn(Colors.red);
     when(() => mockEnv.values).thenReturn({});
+    when(() => mockEnv.sensitiveKeys).thenReturn({});
 
     final navigatorKey = GlobalKey<NavigatorState>();
     final api = EnvironmentApiImpl(mockEnv);

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -10,6 +10,7 @@ void main() {
 
   setUp(() {
     mockEnv = MockEnvironment();
+    when(() => mockEnv.sensitiveKeys).thenReturn({});
   });
 
   testWidgets('should display environment details', (tester) async {
@@ -91,5 +92,38 @@ void main() {
     // Assert
     expect(find.byType(SnackBar), findsOneWidget);
     expect(find.text('Copied "key" to clipboard'), findsOneWidget);
+  });
+
+  testWidgets('should redact sensitive keys and hide copy button', (
+    tester,
+  ) async {
+    // Arrange
+    when(() => mockEnv.name).thenReturn('Dev');
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.color).thenReturn(Colors.blue);
+    when(() => mockEnv.values).thenReturn({
+      'public_key': 'public_123',
+      'secret_key': 'secret_456',
+    });
+    when(() => mockEnv.sensitiveKeys).thenReturn({'secret_key'});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EnvironmentInspector(environment: mockEnv),
+        ),
+      ),
+    );
+
+    // Assert
+    expect(find.text('public_key'), findsOneWidget);
+    expect(find.text('public_123'), findsOneWidget);
+    expect(find.text('secret_key'), findsOneWidget);
+    expect(find.text('secret_456'), findsNothing);
+    expect(find.text('***REDACTED***'), findsOneWidget);
+
+    // Copy button should exist for public_key but not for secret_key
+    // In this case, we expect only one copy button in the entire widget
+    expect(find.byIcon(Icons.copy_all), findsOneWidget);
   });
 }

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment.dart
@@ -17,6 +17,9 @@ abstract class Environment {
 
   /// A map of configuration values (API Keys, Base URLs, etc.).
   Map<String, String> get values;
+
+  /// A set of keys that should be redacted in logs or UI.
+  Set<String> get sensitiveKeys => const {};
 }
 
 /// Convenience extensions to avoid verbose type checks.


### PR DESCRIPTION
# Description
This pull request enhances the security of the `fluent_environment` toolkit by introducing a way to mark specific environment configuration keys as sensitive. When a key is marked as sensitive, its value will be hidden (redacted) in the environment inspector UI and cannot be copied to the clipboard. This prevents accidental exposure of sensitive data like API keys or tokens during development or testing.

## Key Changes
- Added a `sensitiveKeys` property to the `Environment` definition.
- Updated the `EnvironmentInspector` widget to redact values for sensitive keys.
- Disabled the copy-to-clipboard functionality for redacted values.
- Added comprehensive unit tests to ensure sensitive data is properly protected.

## How to use
In your `Environment` implementation, override the `sensitiveKeys` getter:

```dart
@override
Set<String> get sensitiveKeys => {'api_key', 'secret_token'};
```

# Commit Message
fix(environment): redact sensitive keys in environment inspector

---
*PR created automatically by Jules for task [9718828699383464522](https://jules.google.com/task/9718828699383464522) started by @aosorio-avilez*