### PR TITLE
feat(networking): add caching support to networking api

### DIFF
--- a/packages/fluent_networking/fluent_networking/example/lib/main.dart
+++ b/packages/fluent_networking/fluent_networking/example/lib/main.dart
@@ -10,21 +10,40 @@ void main() async {
   runApp(const MainApp());
 }
 
-class MainApp extends StatelessWidget {
+class MainApp extends StatefulWidget {
   const MainApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  State<MainApp> createState() => _MainAppState();
+}
+
+class _MainAppState extends State<MainApp> {
+  late Future<ResponseResult<Map<String, dynamic>>> _future;
+  bool _useCache = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPokemon();
+  }
+
+  void _fetchPokemon() {
     final networkingApi = Fluent.get<NetworkingApi>();
 
-    final future = networkingApi.get<Map<String, dynamic>>(
-      "/pokemon",
-      retryConfig: const RetryConfig(
-        maxRetries: 2,
-        retryInterval: Duration(seconds: 1),
-      ),
-    );
+    setState(() {
+      _future = networkingApi.get<Map<String, dynamic>>(
+        "/pokemon",
+        cacheConfig: _useCache
+            ? const CacheConfig(
+                duration: Duration(minutes: 1),
+              )
+            : const CacheConfig(forceRefresh: true),
+      );
+    });
+  }
 
+  @override
+  Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.red),
@@ -34,9 +53,24 @@ class MainApp extends StatelessWidget {
         appBar: AppBar(
           title: const Text("Fluent Networking Demo"),
           elevation: 2,
+          actions: [
+            Row(
+              children: [
+                const Text("Use Cache"),
+                Switch(
+                  value: _useCache,
+                  onChanged: (value) {
+                    setState(() {
+                      _useCache = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ],
         ),
         body: FutureBuilder<ResponseResult<Map<String, dynamic>>>(
-          future: future,
+          future: _future,
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
@@ -50,31 +84,41 @@ class MainApp extends StatelessWidget {
 
             return switch (result) {
               Success(data: final pokemonData) => _PokemonList(
-                data: pokemonData,
-              ),
+                  data: pokemonData,
+                  onRefresh: _fetchPokemon,
+                ),
               Failure(error: final httpError) => Center(
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(
-                        Icons.error_outline,
-                        size: 48,
-                        color: Colors.red,
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        "Error ${httpError.code ?? 'Unknown'}",
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      Text(httpError.message),
-                    ],
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.error_outline,
+                          size: 48,
+                          color: Colors.red,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          "Error ${httpError.code ?? 'Unknown'}",
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        Text(httpError.message),
+                        const SizedBox(height: 16),
+                        ElevatedButton(
+                          onPressed: _fetchPokemon,
+                          child: const Text("Retry"),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
             };
           },
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: _fetchPokemon,
+          child: const Icon(Icons.refresh),
         ),
       ),
     );
@@ -82,9 +126,10 @@ class MainApp extends StatelessWidget {
 }
 
 class _PokemonList extends StatelessWidget {
-  final Map<String, dynamic> data;
+  const _PokemonList({required this.data, required this.onRefresh});
 
-  const _PokemonList({required this.data});
+  final Map<String, dynamic> data;
+  final VoidCallback onRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -94,24 +139,27 @@ class _PokemonList extends StatelessWidget {
       return const Center(child: Text("No Pokemons found"));
     }
 
-    return ListView.separated(
-      itemCount: results.length,
-      separatorBuilder: (_, __) => const Divider(height: 1),
-      itemBuilder: (context, index) {
-        final pokemon = results[index] as Map<String, dynamic>;
-        final name = pokemon["name"]?.toString() ?? "Unknown";
-        final url = pokemon["url"]?.toString() ?? "";
+    return RefreshIndicator(
+      onRefresh: () async => onRefresh(),
+      child: ListView.separated(
+        itemCount: results.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final pokemon = results[index] as Map<String, dynamic>;
+          final name = pokemon["name"]?.toString() ?? "Unknown";
+          final url = pokemon["url"]?.toString() ?? "";
 
-        return ListTile(
-          leading: CircleAvatar(child: Text(name[0].toUpperCase())),
-          title: Text(
-            name.toUpperCase(),
-            style: const TextStyle(fontWeight: FontWeight.bold),
-          ),
-          subtitle: Text(url),
-          trailing: const Icon(Icons.chevron_right),
-        );
-      },
+          return ListTile(
+            leading: CircleAvatar(child: Text(name[0].toUpperCase())),
+            title: Text(
+              name.toUpperCase(),
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            subtitle: Text(url),
+            trailing: const Icon(Icons.chevron_right),
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/fluent_networking/fluent_networking/example/lib/main.dart
+++ b/packages/fluent_networking/fluent_networking/example/lib/main.dart
@@ -34,9 +34,7 @@ class _MainAppState extends State<MainApp> {
       _future = networkingApi.get<Map<String, dynamic>>(
         "/pokemon",
         cacheConfig: _useCache
-            ? const CacheConfig(
-                duration: Duration(minutes: 1),
-              )
+            ? const CacheConfig(duration: Duration(minutes: 1))
             : const CacheConfig(forceRefresh: true),
       );
     });
@@ -84,35 +82,35 @@ class _MainAppState extends State<MainApp> {
 
             return switch (result) {
               Success(data: final pokemonData) => _PokemonList(
-                  data: pokemonData,
-                  onRefresh: _fetchPokemon,
-                ),
+                data: pokemonData,
+                onRefresh: _fetchPokemon,
+              ),
               Failure(error: final httpError) => Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Icon(
-                          Icons.error_outline,
-                          size: 48,
-                          color: Colors.red,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          "Error ${httpError.code ?? 'Unknown'}",
-                          style: const TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                        Text(httpError.message),
-                        const SizedBox(height: 16),
-                        ElevatedButton(
-                          onPressed: _fetchPokemon,
-                          child: const Text("Retry"),
-                        ),
-                      ],
-                    ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(
+                        Icons.error_outline,
+                        size: 48,
+                        color: Colors.red,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        "Error ${httpError.code ?? 'Unknown'}",
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      Text(httpError.message),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _fetchPokemon,
+                        child: const Text("Retry"),
+                      ),
+                    ],
                   ),
                 ),
+              ),
             };
           },
         ),

--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_cache_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_cache_interceptor.dart
@@ -1,0 +1,75 @@
+import 'package:dio/dio.dart';
+import 'package:fluent_networking/fluent_networking.dart';
+
+/// A networking interceptor that caches requests and responses.
+class NetworkingCacheInterceptor extends Interceptor {
+  /// The key used to store the cache configuration in [RequestOptions.extra].
+  static const extraCacheConfig = 'networking_cache_config';
+
+  final Map<String, _CacheEntry> _cache = {};
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    final cacheConfig = options.extra[extraCacheConfig] as CacheConfig?;
+
+    if (cacheConfig == null) {
+      return super.onRequest(options, handler);
+    }
+
+    if (cacheConfig.forceRefresh) {
+      return super.onRequest(options, handler);
+    }
+
+    final key = cacheConfig.key ?? _buildKey(options);
+    final entry = _cache[key];
+
+    if (entry != null) {
+      if (entry.isValid) {
+        return handler.resolve(
+          Response(
+            requestOptions: options,
+            data: entry.data,
+            statusCode: 200,
+            statusMessage: 'OK (Cached)',
+          ),
+        );
+      } else {
+        _cache.remove(key);
+      }
+    }
+
+    super.onRequest(options, handler);
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    final cacheConfig =
+        response.requestOptions.extra[extraCacheConfig] as CacheConfig?;
+
+    if (cacheConfig != null && response.statusCode == 200) {
+      final key = cacheConfig.key ?? _buildKey(response.requestOptions);
+      _cache[key] = _CacheEntry(
+        data: response.data,
+        expiry: DateTime.now().add(cacheConfig.duration),
+      );
+    }
+
+    super.onResponse(response, handler);
+  }
+
+  String _buildKey(RequestOptions options) {
+    return '${options.method}:${options.uri}:${options.data}';
+  }
+}
+
+class _CacheEntry {
+  _CacheEntry({required this.data, required this.expiry});
+
+  final dynamic data;
+  final DateTime expiry;
+
+  bool get isValid => DateTime.now().isBefore(expiry);
+}

--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_cache_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_cache_interceptor.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:fluent_networking/fluent_networking.dart';
 
@@ -6,6 +8,10 @@ class NetworkingCacheInterceptor extends Interceptor {
   /// The key used to store the cache configuration in [RequestOptions.extra].
   static const extraCacheConfig = 'networking_cache_config';
 
+  /// The maximum number of entries to keep in the cache.
+  static const _maxEntries = 100;
+
+  /// In-memory cache using a LinkedHashMap to maintain insertion order for LRU.
   final Map<String, _CacheEntry> _cache = {};
 
   @override
@@ -25,11 +31,15 @@ class NetworkingCacheInterceptor extends Interceptor {
 
     if (entry != null) {
       if (entry.isValid) {
+        // Move to end to mark as recently used
+        _cache.remove(key);
+        _cache[key] = entry;
+
         return handler.resolve(
           Response(
             requestOptions: options,
             data: entry.data,
-            statusCode: 200,
+            statusCode: entry.statusCode,
             statusMessage: 'OK (Cached)',
           ),
         );
@@ -48,11 +58,20 @@ class NetworkingCacheInterceptor extends Interceptor {
   ) {
     final cacheConfig =
         response.requestOptions.extra[extraCacheConfig] as CacheConfig?;
+    final statusCode = response.statusCode ?? 0;
+    final isSuccess = statusCode >= 200 && statusCode < 300;
 
-    if (cacheConfig != null && response.statusCode == 200) {
+    if (cacheConfig != null && isSuccess) {
       final key = cacheConfig.key ?? _buildKey(response.requestOptions);
+
+      // Evict oldest entry if limit reached
+      if (_cache.length >= _maxEntries && !_cache.containsKey(key)) {
+        _cache.remove(_cache.keys.first);
+      }
+
       _cache[key] = _CacheEntry(
         data: response.data,
+        statusCode: statusCode,
         expiry: DateTime.now().add(cacheConfig.duration),
       );
     }
@@ -61,14 +80,32 @@ class NetworkingCacheInterceptor extends Interceptor {
   }
 
   String _buildKey(RequestOptions options) {
-    return '${options.method}:${options.uri}:${options.data}';
+    final data = options.data;
+    String? dataString;
+
+    try {
+      if (data is Map || data is List) {
+        dataString = jsonEncode(data);
+      } else {
+        dataString = data?.toString();
+      }
+    } on Object catch (_) {
+      dataString = data.toString();
+    }
+
+    return '${options.method}:${options.uri}:$dataString';
   }
 }
 
 class _CacheEntry {
-  _CacheEntry({required this.data, required this.expiry});
+  _CacheEntry({
+    required this.data,
+    required this.statusCode,
+    required this.expiry,
+  });
 
   final dynamic data;
+  final int statusCode;
   final DateTime expiry;
 
   bool get isValid => DateTime.now().isBefore(expiry);

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_api_impl.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_api_impl.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:fluent_networking/fluent_networking.dart';
+import 'package:fluent_networking/src/interceptors/networking_cache_interceptor.dart';
 import 'package:fluent_networking/src/interceptors/networking_retry_interceptor.dart';
 
 class NetworkingApiImpl extends NetworkingApi {
@@ -12,11 +13,12 @@ class NetworkingApiImpl extends NetworkingApi {
     String url, {
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   }) {
     return _execute(
       () => _httpClient.get<dynamic>(
         url,
-        options: _mergeOptions(options, retryConfig),
+        options: _mergeOptions(options, retryConfig, cacheConfig),
       ),
     );
   }
@@ -27,12 +29,13 @@ class NetworkingApiImpl extends NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   }) {
     return _execute(
       () => _httpClient.post<dynamic>(
         url,
         data: body,
-        options: _mergeOptions(options, retryConfig),
+        options: _mergeOptions(options, retryConfig, cacheConfig),
       ),
     );
   }
@@ -43,12 +46,13 @@ class NetworkingApiImpl extends NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   }) {
     return _execute(
       () => _httpClient.put<dynamic>(
         url,
         data: body,
-        options: _mergeOptions(options, retryConfig),
+        options: _mergeOptions(options, retryConfig, cacheConfig),
       ),
     );
   }
@@ -59,12 +63,13 @@ class NetworkingApiImpl extends NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   }) {
     return _execute(
       () => _httpClient.patch<dynamic>(
         url,
         data: body,
-        options: _mergeOptions(options, retryConfig),
+        options: _mergeOptions(options, retryConfig, cacheConfig),
       ),
     );
   }
@@ -75,22 +80,34 @@ class NetworkingApiImpl extends NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   }) {
     return _execute(
       () => _httpClient.delete<dynamic>(
         url,
         data: body,
-        options: _mergeOptions(options, retryConfig),
+        options: _mergeOptions(options, retryConfig, cacheConfig),
       ),
     );
   }
 
-  Options _mergeOptions(Options? options, RetryConfig? retryConfig) {
-    if (retryConfig == null) return options ?? Options();
+  Options _mergeOptions(
+    Options? options,
+    RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
+  ) {
+    if (retryConfig == null && cacheConfig == null) return options ?? Options();
 
     final effectiveOptions = options ?? Options();
     final extra = Map<String, dynamic>.from(effectiveOptions.extra ?? {});
-    extra[NetworkingRetryInterceptor.extraRetryConfig] = retryConfig;
+
+    if (retryConfig != null) {
+      extra[NetworkingRetryInterceptor.extraRetryConfig] = retryConfig;
+    }
+
+    if (cacheConfig != null) {
+      extra[NetworkingCacheInterceptor.extraCacheConfig] = cacheConfig;
+    }
 
     return effectiveOptions.copyWith(extra: extra);
   }

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:fluent_logger_api/fluent_logger_api.dart';
 import 'package:fluent_networking/fluent_networking.dart';
+import 'package:fluent_networking/src/interceptors/networking_cache_interceptor.dart';
 import 'package:fluent_networking/src/interceptors/networking_log_interceptor.dart';
 import 'package:fluent_networking/src/interceptors/networking_retry_interceptor.dart';
 import 'package:fluent_networking/src/networking_api_impl.dart';
@@ -40,12 +41,14 @@ class NetworkingModule extends FluentModule {
           );
         }
 
-        dio.interceptors.add(
-          NetworkingRetryInterceptor(
-            dio: dio,
-            globalRetryConfig: config.retryConfig,
-          ),
-        );
+        dio.interceptors
+          ..add(NetworkingCacheInterceptor())
+          ..add(
+            NetworkingRetryInterceptor(
+              dio: dio,
+              globalRetryConfig: config.retryConfig,
+            ),
+          );
 
         return dio;
       })

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_cache_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_cache_interceptor_test.dart
@@ -1,0 +1,113 @@
+import 'package:fluent_networking/fluent_networking.dart';
+import 'package:fluent_networking/src/interceptors/networking_cache_interceptor.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockRequestInterceptorHandler extends Mock
+    implements RequestInterceptorHandler {}
+
+class MockResponseInterceptorHandler extends Mock
+    implements ResponseInterceptorHandler {}
+
+void main() {
+  late NetworkingCacheInterceptor interceptor;
+  late MockRequestInterceptorHandler requestHandler;
+  late MockResponseInterceptorHandler responseHandler;
+
+  setUp(() {
+    interceptor = NetworkingCacheInterceptor();
+    requestHandler = MockRequestInterceptorHandler();
+    responseHandler = MockResponseInterceptorHandler();
+    registerFallbackValue(RequestOptions(path: '/'));
+    registerFallbackValue(
+      Response<dynamic>(requestOptions: RequestOptions(path: '/')),
+    );
+  });
+
+  test('should not cache if CacheConfig is missing', () {
+    final options = RequestOptions(path: '/test');
+
+    interceptor.onRequest(options, requestHandler);
+
+    verify(() => requestHandler.next(options)).called(1);
+  });
+
+  test('should cache response and return it on subsequent request', () async {
+    const cacheConfig = CacheConfig(duration: Duration(seconds: 1));
+    final options = RequestOptions(
+      path: '/test',
+      extra: {NetworkingCacheInterceptor.extraCacheConfig: cacheConfig},
+    );
+    final response = Response<dynamic>(
+      requestOptions: options,
+      data: {'key': 'value'},
+      statusCode: 200,
+    );
+
+    // First request: handle response to cache it
+    interceptor.onResponse(response, responseHandler);
+    verify(() => responseHandler.next(response)).called(1);
+
+    // Second request: should resolve with cached response
+    interceptor.onRequest(options, requestHandler);
+
+    verify(
+      () => requestHandler.resolve(
+        any(
+          that: isA<Response<dynamic>>().having(
+            (r) => r.statusMessage,
+            'statusMessage',
+            'OK (Cached)',
+          ),
+        ),
+      ),
+    ).called(1);
+  });
+
+  test('should not return cached response if expired', () async {
+    const cacheConfig = CacheConfig(duration: Duration(milliseconds: 10));
+    final options = RequestOptions(
+      path: '/test',
+      extra: {NetworkingCacheInterceptor.extraCacheConfig: cacheConfig},
+    );
+    final response = Response<dynamic>(
+      requestOptions: options,
+      data: {'key': 'value'},
+      statusCode: 200,
+    );
+
+    interceptor.onResponse(response, responseHandler);
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    interceptor.onRequest(options, requestHandler);
+
+    verify(() => requestHandler.next(options)).called(1);
+  });
+
+  test('should force refresh even if cached response exists', () {
+    const cacheConfig = CacheConfig(duration: Duration(seconds: 1));
+    final options = RequestOptions(
+      path: '/test',
+      extra: {NetworkingCacheInterceptor.extraCacheConfig: cacheConfig},
+    );
+    final response = Response<dynamic>(
+      requestOptions: options,
+      data: {'key': 'value'},
+      statusCode: 200,
+    );
+
+    interceptor.onResponse(response, responseHandler);
+
+    final forceOptions = options.copyWith(
+      extra: {
+        NetworkingCacheInterceptor.extraCacheConfig:
+            const CacheConfig(forceRefresh: true),
+      },
+    );
+
+    interceptor.onRequest(forceOptions, requestHandler);
+
+    verify(() => requestHandler.next(forceOptions)).called(1);
+  });
+}

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_cache_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_cache_interceptor_test.dart
@@ -101,8 +101,9 @@ void main() {
 
     final forceOptions = options.copyWith(
       extra: {
-        NetworkingCacheInterceptor.extraCacheConfig:
-            const CacheConfig(forceRefresh: true),
+        NetworkingCacheInterceptor.extraCacheConfig: const CacheConfig(
+          forceRefresh: true,
+        ),
       },
     );
 

--- a/packages/fluent_networking/fluent_networking_api/lib/fluent_networking_api.dart
+++ b/packages/fluent_networking/fluent_networking_api/lib/fluent_networking_api.dart
@@ -1,3 +1,4 @@
+export 'src/cache_config.dart';
 export 'src/networking_api.dart';
 export 'src/response_result.dart';
 export 'src/retry_config.dart';

--- a/packages/fluent_networking/fluent_networking_api/lib/src/cache_config.dart
+++ b/packages/fluent_networking/fluent_networking_api/lib/src/cache_config.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+/// Configuration for caching a networking request.
+class CacheConfig extends Equatable {
+  /// Creates a [CacheConfig].
+  const CacheConfig({
+    this.duration = const Duration(minutes: 5),
+    this.forceRefresh = false,
+    this.key,
+  });
+
+  /// The duration for which the response should be cached.
+  /// Defaults to 5 minutes.
+  final Duration duration;
+
+  /// Whether to force a refresh of the cache.
+  /// If true, the request will be made even if a cached response exists.
+  final bool forceRefresh;
+
+  /// An optional custom key for the cache.
+  /// If not provided, the request URI and parameters will be used.
+  final String? key;
+
+  @override
+  List<Object?> get props => [duration, forceRefresh, key];
+}

--- a/packages/fluent_networking/fluent_networking_api/lib/src/networking_api.dart
+++ b/packages/fluent_networking/fluent_networking_api/lib/src/networking_api.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:fluent_networking_api/src/cache_config.dart';
 import 'package:fluent_networking_api/src/response_result.dart';
 import 'package:fluent_networking_api/src/retry_config.dart';
 
@@ -10,6 +11,7 @@ abstract class NetworkingApi {
     String url, {
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   });
 
   /// Makes a POST request to the specific url
@@ -19,6 +21,7 @@ abstract class NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   });
 
   /// Makes a PATCH request to the specific url
@@ -28,6 +31,7 @@ abstract class NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   });
 
   /// Makes a PUT request to the specific url
@@ -37,6 +41,7 @@ abstract class NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   });
 
   /// Makes a DELETE request to the specific url
@@ -46,5 +51,6 @@ abstract class NetworkingApi {
     Object? body,
     Options? options,
     RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
   });
 }


### PR DESCRIPTION
This PR introduces a new caching capability to the `fluent_networking` package. Developers can now easily cache network requests by providing a `CacheConfig` to the `NetworkingApi` methods.

### Why this is valuable:
- **Improved Performance:** Reduces redundant network calls by serving data from a local in-memory cache.
- **Developer Experience (DX):** Provides a simple, declarative way to enable caching per request without manual interceptor management.
- **Customization:** Supports configurable cache duration, force-refresh logic, and custom cache keys.

### Changes:
- Added `CacheConfig` to `fluent_networking_api`.
- Updated `NetworkingApi` interface to include `cacheConfig` parameters.
- Implemented `NetworkingCacheInterceptor` in `fluent_networking`.
- Integrated the interceptor into `NetworkingModule`.
- Updated the `example` app to demonstrate caching with a toggleable UI.
- Added comprehensive unit tests for the caching logic.

---
*PR created automatically by Jules for task [3680857975059166255](https://jules.google.com/task/3680857975059166255) started by @aosorio-avilez*