### PR TITLE
feat(navigation): expose navigatorKey in NavigationApi

### DIFF
--- a/packages/fluent_navigation/fluent_navigation/lib/src/api/navigation_api_impl.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/api/navigation_api_impl.dart
@@ -3,10 +3,15 @@ import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 class NavigationApiImpl extends NavigationApi {
-  NavigationApiImpl(this._router);
+  NavigationApiImpl(this._router, this._navigatorKey);
 
   /// Internal reference to the registered [GoRouter].
   final GoRouter _router;
+
+  final GlobalKey<NavigatorState> _navigatorKey;
+
+  @override
+  GlobalKey<NavigatorState> get navigatorKey => _navigatorKey;
 
   @override
   void navigateTo(

--- a/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
@@ -57,7 +57,7 @@ class NavigationModule extends FluentModule {
       // Use lazy singleton to defer initialization
       // until the API is actually used.
       ..registerLazySingleton<NavigationApi>(
-        (it) => NavigationApiImpl(it.get<GoRouter>()),
+        (it) => NavigationApiImpl(it.get<GoRouter>(), rootNavigatorKey),
       );
   }
 }

--- a/packages/fluent_navigation/fluent_navigation/test/src/api/navigation_api_impl_test.dart
+++ b/packages/fluent_navigation/fluent_navigation/test/src/api/navigation_api_impl_test.dart
@@ -33,6 +33,13 @@ void main() {
     expect(router, isA<RouterConfig<Object>>());
   });
 
+  test('verify navigatorKey', () async {
+    final navigatorKey = Fluent.get<NavigationApi>().navigatorKey;
+
+    expect(navigatorKey, isA<GlobalKey<NavigatorState>>());
+    expect(navigatorKey, equals(rootNavigatorKey));
+  });
+
   testWidgets('verify canPop returns false on initial route (root)', (
     tester,
   ) async {

--- a/packages/fluent_navigation/fluent_navigation_api/lib/src/navigation_api.dart
+++ b/packages/fluent_navigation/fluent_navigation_api/lib/src/navigation_api.dart
@@ -33,4 +33,7 @@ abstract class NavigationApi {
 
   /// Get the router configuration
   RouterConfig<Object> get router;
+
+  /// Get the navigator key
+  GlobalKey<NavigatorState> get navigatorKey;
 }


### PR DESCRIPTION
This PR introduces a significant enhancement to the `fluent_navigation` package by exposing the `navigatorKey` through the public `NavigationApi` interface. This allows developers and other modules to access the global `NavigatorState` directly, which is crucial for displaying overlays, dialogs, or bottom sheets from parts of the application that don't have a direct `Navigator` context (such as when using the `builder` property of `MaterialApp`).

Additionally, this PR prepares the packages for a new release, incorporating recent performance optimizations for dependency injection and startup.

## Changes

### fluent_navigation_api (v1.1.0)
- Added `navigatorKey` getter to the `NavigationApi` abstract class.

### fluent_navigation (v1.6.0)
- Implemented `navigatorKey` in `NavigationApiImpl`.
- Updated `NavigationModule` to properly inject the `rootNavigatorKey`.
- Added unit tests to verify the correct exposure of the `navigatorKey`.
- Included performance optimizations for internal dependency resolution.

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
