### PR TITLE
fix(navigation): resolve pub.dev analysis issues and fix changelog order

### DIFF
--- a/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
@@ -1,34 +1,55 @@
-## 0.0.1
+## 1.6.1
 
-* Initial version.
+* **Fixes**: Fixed analysis issues on pub.dev by making dependency registration and retrieval more explicit.
 
-## 0.0.2
+## 1.6.0
 
-* Class `FluentRoute` was added to define routes (This class was removed from `fluent_sdk` package)
-* A `Registry` extension was added in order to define the `registerRoute` method (This method was removed from `Registry` interface on `fluent_sdk`)
-* Document all the public APIs
+*   **Features**: Added `navigatorKey` to `NavigationApi` to allow access to the global navigator state.
+*   **Improvements**: Optimized dependency injection and internal router initialization for better startup performance.
 
-## 0.0.2+1
+## 1.5.0
 
-* Package `fluent_navigation_api` was updated to `v0.0.2+1`
+* lazy initialization
+* runtime optimization
+* Fix `fluent_navigation` strict exports
+* Enable const constructors for NavigationModule
+* Upgrade `go_router` dependency to `^17.0.1`
+* Upgrade `collection` dependency to `^1.19.1`
 
-## 0.0.3
+## 1.4.0
 
-* Package `fluent_navigation_api` was updated to `v0.0.3`
-* Package `fluent_sdk` was added
+* BREAKING CHANGE: Updated `fluent_sdk` dependency to `^0.5.0`
+* REFACTOR: Renamed `build` method to `onCreate` in `NavigationModule`
+* CHORE: Recreated example platforms and updated READMEs.
 
-## 0.0.4
+## 1.3.1
 
-* `pop` method was added in order to let users go back to previous routes if is possible
+* New parameter `refreshListenable` was added to `NavigationModule` in order to let users listen to `GoRouter` refresh streams
 
-## 0.0.5
+## 1.3.0
 
-* Package `fluent_sdk` was updated to `v0.2.0`
+* Upgrade fluent_sdk version to v0.4.0
 
-## 0.0.6
+## 1.2.2
 
-* Class `FluentRoute` was removed
-* `registerRoute` now use `GoRoute` instead of `FluentRoute` in order to expose more out-of-the-box functionalities 
+* Upgrade interface `fluent_navigation_api` to `v1.0.1`
+
+## 1.2.1
+
+* New method `canPop` was added in order to let users know if they can go back to previous routes
+
+## 1.2.0
+
+* Upgrade package to flutter version v3.35
+
+## 1.1.0
+
+* Package `go_router` was updated to `v13.2.1`
+* Package `collection` was updated to `v1.18.0`
+* Package example was updated to latest version
+* Example android and ios platform updated to latest versions
+* Example web platform enabled
+* Dev dependencies updated
 
 ## 1.0.0
 
@@ -40,51 +61,34 @@
 * Package `collection` was updated to `v1.17.1`
 * Package `very_good_analysis` was updated to `v5.0.0+1`
 
-## 1.1.0
+## 0.0.6
 
-* Package `go_router` was updated to `v13.2.1`
-* Package `collection` was updated to `v1.18.0`
-* Package example was updated to latest version
-* Example android and ios platform updated to latest versions
-* Example web platform enabled
-* Dev dependencies updated
+* Class `FluentRoute` was removed
+* `registerRoute` now use `GoRoute` instead of `FluentRoute` in order to expose more out-of-the-box functionalities 
 
-## 1.2.0
+## 0.0.5
 
-* Upgrade package to flutter version v3.35
+* Package `fluent_sdk` was updated to `v0.2.0`
 
-## 1.2.1
+## 0.0.4
 
-* New method `canPop` was added in order to let users know if they can go back to previous routes
+* `pop` method was added in order to let users go back to previous routes if is possible
 
-## 1.2.2
+## 0.0.3
 
-* Upgrade interface `fluent_navigation_api` to `v1.0.1`
+* Package `fluent_navigation_api` was updated to `v0.0.3`
+* Package `fluent_sdk` was added
 
-## 1.3.0
+## 0.0.2+1
 
-* Upgrade fluent_sdk version to v0.4.0
+* Package `fluent_navigation_api` was updated to `v0.0.2+1`
 
-## 1.3.1
+## 0.0.2
 
-* New parameter `refreshListenable` was added to `NavigationModule` in order to let users listen to `GoRouter` refresh streams
+* Class `FluentRoute` was added to define routes (This class was removed from `fluent_sdk` package)
+* A `Registry` extension was added in order to define the `registerRoute` method (This method was removed from `Registry` interface on `fluent_sdk`)
+* Document all the public APIs
 
-## 1.4.0
+## 0.0.1
 
-* BREAKING CHANGE: Updated `fluent_sdk` dependency to `^0.5.0`
-* REFACTOR: Renamed `build` method to `onCreate` in `NavigationModule`
-* CHORE: Recreated example platforms and updated READMEs.
-
-## 1.5.0
-
-* lazy initialization
-* runtime optimization
-* Fix `fluent_navigation` strict exports
-* Enable const constructors for NavigationModule
-* Upgrade `go_router` dependency to `^17.0.1`
-* Upgrade `collection` dependency to `^1.19.1`
-
-## 1.6.0
-
-*   **Features**: Added `navigatorKey` to `NavigationApi` to allow access to the global navigator state.
-*   **Improvements**: Optimized dependency injection and internal router initialization for better startup performance.
+* Initial version.

--- a/packages/fluent_navigation/fluent_navigation/analysis_options.yaml
+++ b/packages/fluent_navigation/fluent_navigation/analysis_options.yaml
@@ -3,6 +3,7 @@ include: package:very_good_analysis/analysis_options.yaml
 analyzer:
   errors:
     invalid_annotation_target: ignore
+    unnecessary_ignore: ignore
 
 linter:
   rules:

--- a/packages/fluent_navigation/fluent_navigation/analysis_options.yaml
+++ b/packages/fluent_navigation/fluent_navigation/analysis_options.yaml
@@ -3,7 +3,6 @@ include: package:very_good_analysis/analysis_options.yaml
 analyzer:
   errors:
     invalid_annotation_target: ignore
-    unnecessary_ignore: ignore
 
 linter:
   rules:

--- a/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
@@ -49,7 +49,7 @@ class NavigationModule extends FluentModule {
       ..registerLazySingleton<InternalNavigationApi>(
         (it) {
           if (!it.isRegistered<FluentRoutes>()) {
-            it.registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
+            it.registerSingleton<FluentRoutes>((it) => <RouteBase>[]);
           }
           return InternalNavigationApiImpl(it<FluentRoutes>());
         },

--- a/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
@@ -49,7 +49,7 @@ class NavigationModule extends FluentModule {
       ..registerLazySingleton<InternalNavigationApi>(
         (it) {
           if (!it.isRegistered<FluentRoutes>()) {
-            it.registerSingleton<FluentRoutes>((_) => <RouteBase>[]);
+            it.registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
           }
           return InternalNavigationApiImpl(it<FluentRoutes>());
         },

--- a/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
@@ -49,6 +49,7 @@ class NavigationModule extends FluentModule {
       ..registerLazySingleton<InternalNavigationApi>(
         (it) {
           if (!it.isRegistered<FluentRoutes>()) {
+            // ignore: avoid_types_on_closure_parameters, Required for pub.dev analysis compatibility during downgrade tests.
             it.registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
           }
           return InternalNavigationApiImpl(it<FluentRoutes>());

--- a/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/navigation_module.dart
@@ -49,7 +49,6 @@ class NavigationModule extends FluentModule {
       ..registerLazySingleton<InternalNavigationApi>(
         (it) {
           if (!it.isRegistered<FluentRoutes>()) {
-            // ignore: avoid_types_on_closure_parameters, Required for pub.dev analysis compatibility during downgrade tests.
             it.registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
           }
           return InternalNavigationApiImpl(it<FluentRoutes>());

--- a/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
@@ -9,7 +9,6 @@ extension RegistryExtension on Registry {
   /// to navigate later through the navigation api
   void registerRoute(RouteBase route) {
     if (!isRegistered<FluentRoutes>()) {
-      // ignore: avoid_types_on_closure_parameters, Required for pub.dev analysis compatibility during downgrade tests.
       registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
     }
     this<FluentRoutes>().add(route);

--- a/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
@@ -9,8 +9,8 @@ extension RegistryExtension on Registry {
   /// to navigate later through the navigation api
   void registerRoute(RouteBase route) {
     if (!isRegistered<FluentRoutes>()) {
-      registerSingleton<FluentRoutes>((it) => <RouteBase>[]);
+      registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
     }
-    get<FluentRoutes>().add(route);
+    this<FluentRoutes>().add(route);
   }
 }

--- a/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
@@ -9,6 +9,7 @@ extension RegistryExtension on Registry {
   /// to navigate later through the navigation api
   void registerRoute(RouteBase route) {
     if (!isRegistered<FluentRoutes>()) {
+      // ignore: avoid_types_on_closure_parameters, Required for pub.dev analysis compatibility during downgrade tests.
       registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
     }
     this<FluentRoutes>().add(route);

--- a/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/registry_extension.dart
@@ -9,7 +9,7 @@ extension RegistryExtension on Registry {
   /// to navigate later through the navigation api
   void registerRoute(RouteBase route) {
     if (!isRegistered<FluentRoutes>()) {
-      registerSingleton<FluentRoutes>((Registry it) => <RouteBase>[]);
+      registerSingleton<FluentRoutes>((it) => <RouteBase>[]);
     }
     this<FluentRoutes>().add(route);
   }

--- a/packages/fluent_navigation/fluent_navigation/pubspec.yaml
+++ b/packages/fluent_navigation/fluent_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_navigation
 description: Package that provides a simple way to navigate within your app
-version: 1.6.0
+version: 1.6.1
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_navigation/fluent_navigation
 

--- a/packages/fluent_navigation/fluent_navigation_api/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation_api/CHANGELOG.md
@@ -1,37 +1,37 @@
-## 0.0.1
+## 1.1.0
 
-* Initial version.
+*   Added `navigatorKey` getter to `NavigationApi` interface.
 
-## 0.0.2
+## 1.0.2
 
-* Version of `fluent_sdk` was updated to v0.1.1
-* Public APIs was documented
+* Update version to 1.0.2
 
-## 0.0.2+1
+## 1.0.1
 
-* `flutter_test` dev dependency removed
-
-## 0.0.3
-
-* Dependency `fluent_sdk` was removed
-
-## 0.0.4
-
-* `pop` method was added in order to let users go back to previous routes if is possible
+* `canPop` method was added in order to let users know if they can go back to previous routes if is possible
 
 ## 1.0.0
 
 * `pop` method signature was changed in order to be able to use it without any parameter
 * `router` method was changed to getter method to more convenient way to access to it
 
-## 1.0.1
+## 0.0.4
 
-* `canPop` method was added in order to let users know if they can go back to previous routes if is possible
+* `pop` method was added in order to let users go back to previous routes if is possible
 
-## 1.0.2
+## 0.0.3
 
-* Update version to 1.0.2
+* Dependency `fluent_sdk` was removed
 
-## 1.1.0
+## 0.0.2+1
 
-*   Added `navigatorKey` getter to `NavigationApi` interface.
+* `flutter_test` dev dependency removed
+
+## 0.0.2
+
+* Version of `fluent_sdk` was updated to v0.1.1
+* Public APIs was documented
+
+## 0.0.1
+
+* Initial version.


### PR DESCRIPTION
This hotfix addresses the low score (70/160) on `pub.dev` for the `fluent_navigation` v1.6.0 release. The issues were primarily caused by "downgrade analysis" failures, where the analyzer could not correctly infer types or resolve methods on the `Registry` interface when using the minimum allowed versions of dependencies.

## Summary of Changes

### 🛠️ Fixes
- **Explicit Type Inference**: Added explicit `Registry` types to the closure parameters in `registerSingleton` calls within `NavigationModule`. This ensures the analyzer correctly identifies the registry instance regardless of the dependency resolution state.
- **Robust Method Resolution**: Updated `RegistryExtension` to use the callable interface of the SDK (`this<T>()`) instead of the `get<T>()` method. This resolves the `UNDEFINED_METHOD` error reported by `pub.dev` during its internal analysis.

### 🧹 Maintenance
- **Changelog Reordering**: Fixed the order of `CHANGELOG.md` in both `fluent_navigation` and `fluent_navigation_api` packages to follow the project standard (descending order, newest versions at the top).
- **Version Bump**: Bumped `fluent_navigation` to `v1.6.1`.

## Verification Results

The changes were verified locally using the following process:
1. Ran `flutter pub downgrade` to force the use of minimum dependency versions.
2. Ran `flutter analyze`, which now completes with **No issues found!** (previously failing in the same environment).
3. Ran all unit tests to ensure no regressions were introduced.

---

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [x] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor (performance optimizations)
- [x] ✅ Build configuration change (version bump)
- [x] 📝 Documentation (changelog order)
- [ ] 🗑️ Trash
