### PR TITLE
fix(networking): redact sensitive query parameters in log interceptor

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -13,6 +13,7 @@ class NetworkingLogInterceptor extends Interceptor {
     required LoggerApi? logger,
     Set<String>? sensitiveHeaders,
     Set<String>? sensitiveBodyKeys,
+    Set<String>? sensitiveQueryParams,
   }) : _logger = logger,
        _sensitiveHeaders = {
          ..._defaultSensitiveHeaders,
@@ -20,17 +21,31 @@ class NetworkingLogInterceptor extends Interceptor {
            ...sensitiveHeaders.map((e) => e.toLowerCase()),
        },
        _sensitiveBodyKeys =
-           sensitiveBodyKeys?.map((e) => e.toLowerCase()).toSet() ?? const {};
+           sensitiveBodyKeys?.map((e) => e.toLowerCase()).toSet() ?? const {},
+       _sensitiveQueryParams = {
+         ..._defaultSensitiveQueryParams,
+         if (sensitiveQueryParams != null)
+           ...sensitiveQueryParams.map((e) => e.toLowerCase()),
+       };
 
   final LoggerApi? _logger;
   final Set<String> _sensitiveHeaders;
   final Set<String> _sensitiveBodyKeys;
+  final Set<String> _sensitiveQueryParams;
 
   static const _defaultSensitiveHeaders = {
     'authorization',
     'cookie',
     'proxy-authorization',
     'set-cookie',
+  };
+
+  static const _defaultSensitiveQueryParams = {
+    'api_key',
+    'apikey',
+    'access_token',
+    'token',
+    'secret',
   };
 
   static const _extraStartTime = 'networking_start_time';
@@ -47,7 +62,7 @@ class NetworkingLogInterceptor extends Interceptor {
   Iterable<String> _yieldRequestLog(RequestOptions options) sync* {
     yield '┌ HTTP REQUEST ───────────────────────────────────────────────────';
     yield '│ Method: ${options.method.toUpperCase()}';
-    yield '│ URI: ${options.uri}';
+    yield '│ URI: ${_sanitizeUri(options.uri)}';
     if (options.headers.isNotEmpty) {
       yield '│ Headers:';
       for (final header in _formatHeaders(options.headers)) {
@@ -79,7 +94,7 @@ class NetworkingLogInterceptor extends Interceptor {
 
     yield '┌ HTTP RESPONSE ──────────────────────────────────────────────────';
     yield '│ Success: [${response.requestOptions.method.toUpperCase()}] '
-        '${response.requestOptions.uri}';
+        '${_sanitizeUri(response.requestOptions.uri)}';
     yield '│ Status: $status $statusName';
     if (duration != null) {
       yield '│ Duration: ${duration}ms';
@@ -112,7 +127,7 @@ class NetworkingLogInterceptor extends Interceptor {
 
     yield '┌ HTTP ERROR ─────────────────────────────────────────────────────';
     yield '│ Failure: [${err.requestOptions.method.toUpperCase()}] '
-        '${err.requestOptions.uri}';
+        '${_sanitizeUri(err.requestOptions.uri)}';
     if (status != null) {
       yield '│ Status: $status';
     }
@@ -159,6 +174,24 @@ class NetworkingLogInterceptor extends Interceptor {
       // Return raw data if it fails to format as JSON
     }
     return data.toString();
+  }
+
+  String _sanitizeUri(Uri uri) {
+    if (uri.queryParameters.isEmpty) return uri.toString();
+
+    final queryParameters = Map<String, dynamic>.from(uri.queryParametersAll);
+    var hasChanges = false;
+
+    for (final key in queryParameters.keys) {
+      if (_sensitiveQueryParams.contains(key.toLowerCase())) {
+        queryParameters[key] = ['***REDACTED***'];
+        hasChanges = true;
+      }
+    }
+
+    if (!hasChanges) return uri.toString();
+
+    return uri.replace(queryParameters: queryParameters).toString();
   }
 
   dynamic _sanitizeBody(dynamic data) {

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_config.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_config.dart
@@ -8,6 +8,7 @@ class NetworkingConfig {
     this.enableLog = false,
     this.sensitiveHeaders = const {},
     this.sensitiveBodyKeys = const {},
+    this.sensitiveQueryParams = const {},
     this.retryConfig,
   });
 
@@ -25,6 +26,9 @@ class NetworkingConfig {
 
   /// Keys in the JSON body to redact in logs
   final Set<String> sensitiveBodyKeys;
+
+  /// Query parameters to redact in logs
+  final Set<String> sensitiveQueryParams;
 
   /// Global retry configuration
   final RetryConfig? retryConfig;

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
@@ -37,6 +37,7 @@ class NetworkingModule extends FluentModule {
               logger: logger,
               sensitiveHeaders: config.sensitiveHeaders,
               sensitiveBodyKeys: config.sensitiveBodyKeys,
+              sensitiveQueryParams: config.sensitiveQueryParams,
             ),
           );
         }

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
@@ -88,6 +88,63 @@ void main() {
       );
     });
 
+    test('onRequest should redact default sensitive query parameters', () {
+      final options = RequestOptions(
+        path: 'https://api.example.com?api_key=secret-key&token=my-token&q=flutter',
+        method: 'GET',
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(
+            that: allOf(
+              contains('api_key=%2A%2A%2AREDACTED%2A%2A%2A'),
+              contains('token=%2A%2A%2AREDACTED%2A%2A%2A'),
+              contains('q=flutter'),
+            ),
+          ),
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('secret-key')),
+        ),
+      );
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('my-token')),
+        ),
+      );
+    });
+
+    test('onRequest should redact custom sensitive query parameters', () {
+      final customInterceptor = NetworkingLogInterceptor(
+        logger: mockLoggerApi,
+        sensitiveQueryParams: {'my_param'},
+      );
+      final options = RequestOptions(
+        path: 'https://api.example.com?my_param=secret-value',
+        method: 'GET',
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      customInterceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('my_param=%2A%2A%2AREDACTED%2A%2A%2A')),
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('secret-value')),
+        ),
+      );
+    });
+
     test('onRequest should log request and sanitize sensitive body keys', () {
       final customInterceptor = NetworkingLogInterceptor(
         logger: mockLoggerApi,

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
@@ -90,7 +90,8 @@ void main() {
 
     test('onRequest should redact default sensitive query parameters', () {
       final options = RequestOptions(
-        path: 'https://api.example.com?api_key=secret-key&token=my-token&q=flutter',
+        path:
+            'https://api.example.com?api_key=secret-key&token=my-token&q=flutter',
         method: 'GET',
       );
       final handler = MockRequestInterceptorHandler();

--- a/packages/fluent_networking/fluent_networking/test/src/networking_module_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/networking_module_test.dart
@@ -16,6 +16,7 @@ void main() {
     when(() => config.enableLog).thenReturn(true);
     when(() => config.sensitiveHeaders).thenReturn({});
     when(() => config.sensitiveBodyKeys).thenReturn({});
+    when(() => config.sensitiveQueryParams).thenReturn({});
     when(() => config.retryConfig).thenReturn(null);
 
     await Fluent.build([NetworkingModule(config: config)]);


### PR DESCRIPTION
# Description

This PR enhances the security of the `fluent_networking` package by implementing automatic redaction of sensitive query parameters in the `NetworkingLogInterceptor`. 

Previously, if a request URL contained sensitive information such as an `api_key` or `access_token` in the query string, these would be logged in plain text. This enhancement ensures that common sensitive keys are redacted by default, and also provides developers with the ability to specify custom sensitive query parameters through the `NetworkingConfig`.

### For a non-technical audience:
We've improved the security of our networking tools to better protect your data. When the app communicates with servers, it sometimes uses "query parameters" in web addresses to send information. Some of this information, like API keys or security tokens, should stay private. This change automatically detects and hides these sensitive details in the app's internal logs, ensuring that private credentials aren't accidentally exposed if someone looks at the logs.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) specification.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

---
*PR created automatically by Jules for task [4087228752912749299](https://jules.google.com/task/4087228752912749299) started by @aosorio-avilez*