### PR TITLE
feat(localization): support configurable base locale in code generator

### DIFF
--- a/packages/fluent_localization/fluent_localization/CHANGELOG.md
+++ b/packages/fluent_localization/fluent_localization/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.0
+
+* **Feature**: Added support for a configurable base locale in the code generator.
+* **Feature**: The CLI tool now accepts an optional third argument to specify the base locale file (e.g., `es` for `es.json`).
+* **Enhancement**: Improved error reporting when the base localization file is missing or invalid.
+
 ## 1.6.1
 
 * **Fix**: Resolved linter warnings in the CLI tool and generator logic.

--- a/packages/fluent_localization/fluent_localization/README.md
+++ b/packages/fluent_localization/fluent_localization/README.md
@@ -46,10 +46,20 @@ To avoid using strings keys manually, you can generate type-safe keys using the 
 Run this command in your project root:
 
 ```bash
-fvm dart run fluent_localization:generate
+fvm dart run fluent_localization:generate [inputPath] [outputPath] [baseLocale]
 ```
 
-This will create a file at `lib/src/api/localization_keys.g.dart`.
+By default, it uses:
+- `inputPath`: `assets/languages`
+- `outputPath`: `lib/localization_keys.g.dart`
+- `baseLocale`: `en` (uses `en.json` as source)
+
+Example using Spanish as the base language:
+```bash
+fvm dart run fluent_localization:generate assets/languages lib/localization_keys.g.dart es
+```
+
+This will create a file at `lib/localization_keys.g.dart` using `es.json` to generate the keys.
 
 ### 2. Use it in your code
 Import the generated file and use the `context.loc` extension:

--- a/packages/fluent_localization/fluent_localization/bin/generate.dart
+++ b/packages/fluent_localization/fluent_localization/bin/generate.dart
@@ -6,6 +6,7 @@ void main(List<String> args) async {
 
   var inputPath = 'assets/languages';
   var outputPath = 'lib/localization_keys.g.dart';
+  var baseLocale = 'en';
 
   if (args.isNotEmpty) {
     inputPath = args[0];
@@ -15,9 +16,14 @@ void main(List<String> args) async {
     outputPath = args[1];
   }
 
+  if (args.length > 2) {
+    baseLocale = args[2];
+  }
+
   final generator = LocalizationGenerator(
     inputPath: inputPath,
     outputPath: outputPath,
+    baseLocale: baseLocale,
   );
 
   try {

--- a/packages/fluent_localization/fluent_localization/lib/src/generator/localization_generator.dart
+++ b/packages/fluent_localization/fluent_localization/lib/src/generator/localization_generator.dart
@@ -8,10 +8,12 @@ class LocalizationGenerator {
   const LocalizationGenerator({
     this.inputPath = 'assets/languages',
     this.outputPath = 'lib/localization_keys.g.dart',
+    this.baseLocale = 'en',
   });
 
   final String inputPath;
   final String outputPath;
+  final String baseLocale;
 
   static final _argRegExp = RegExp(r'\{([^\}]+)\}');
 
@@ -23,17 +25,19 @@ class LocalizationGenerator {
       throw Exception('Directory not found: $inputPath');
     }
 
-    final englishFile = File('$inputPath/en.json');
+    final baseFile = File('$inputPath/$baseLocale.json');
     // ignore: avoid_slow_async_io, Required for CLI tool to read the base translation file.
-    if (!await englishFile.exists()) {
-      throw Exception('Base localization file not found: $inputPath/en.json');
+    if (!await baseFile.exists()) {
+      throw Exception(
+        'Base localization file not found: $inputPath/$baseLocale.json',
+      );
     }
 
-    final content = await englishFile.readAsString();
+    final content = await baseFile.readAsString();
     final dynamic jsonMap = json.decode(content);
 
     if (jsonMap is! Map<String, dynamic>) {
-      throw Exception('Invalid JSON format in en.json');
+      throw Exception('Invalid JSON format in $baseLocale.json');
     }
 
     final entries = <String, String>{};

--- a/packages/fluent_localization/fluent_localization/pubspec.yaml
+++ b/packages/fluent_localization/fluent_localization/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_localization
 description: Package that allows you to set up and use translations in an easy and quick way
-version: 1.6.1
+version: 1.7.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_localization/fluent_localization
 

--- a/packages/fluent_localization/fluent_localization/test/src/generator/localization_generator_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/generator/localization_generator_test.dart
@@ -105,13 +105,31 @@ void main() {
       expect(content, contains("'category': category"));
     });
 
-    test('should throw if en.json is missing', () async {
+    test('should throw if base locale file is missing', () async {
       final generator = LocalizationGenerator(
         inputPath: inputPath,
         outputPath: outputPath,
+        baseLocale: 'fr',
       );
 
       expect(generator.generate(), throwsException);
+    });
+
+    test('should generate correct code from a different base locale (es.json)',
+        () async {
+      final file = File('$inputPath/es.json');
+      await file.writeAsString('{"hola": "Hola Mundo"}');
+
+      final generator = LocalizationGenerator(
+        inputPath: inputPath,
+        outputPath: outputPath,
+        baseLocale: 'es',
+      );
+
+      await generator.generate();
+
+      final content = await File(outputPath).readAsString();
+      expect(content, contains("String get hola => _context.tr('hola');"));
     });
   });
 }

--- a/packages/fluent_localization/fluent_localization/test/src/generator/localization_generator_test.dart
+++ b/packages/fluent_localization/fluent_localization/test/src/generator/localization_generator_test.dart
@@ -115,21 +115,23 @@ void main() {
       expect(generator.generate(), throwsException);
     });
 
-    test('should generate correct code from a different base locale (es.json)',
-        () async {
-      final file = File('$inputPath/es.json');
-      await file.writeAsString('{"hola": "Hola Mundo"}');
+    test(
+      'should generate correct code from a different base locale (es.json)',
+      () async {
+        final file = File('$inputPath/es.json');
+        await file.writeAsString('{"hola": "Hola Mundo"}');
 
-      final generator = LocalizationGenerator(
-        inputPath: inputPath,
-        outputPath: outputPath,
-        baseLocale: 'es',
-      );
+        final generator = LocalizationGenerator(
+          inputPath: inputPath,
+          outputPath: outputPath,
+          baseLocale: 'es',
+        );
 
-      await generator.generate();
+        await generator.generate();
 
-      final content = await File(outputPath).readAsString();
-      expect(content, contains("String get hola => _context.tr('hola');"));
-    });
+        final content = await File(outputPath).readAsString();
+        expect(content, contains("String get hola => _context.tr('hola');"));
+      },
+    );
   });
 }


### PR DESCRIPTION
This update improves the localization tool by allowing developers to choose which language file (like Spanish instead of English) should be the primary source for generating code. This ensures that even if a project starts with a different default language, the automatic code generation for translations works perfectly and remains type-safe.

## Summary of Changes
- **Generator Flexibility**: The `LocalizationGenerator` now supports a `baseLocale` parameter, removing the hardcoded dependency on `en.json`.
- **Enhanced CLI**: The command-line tool now accepts an optional third argument to specify the base locale (e.g., `es` to use `es.json`).
- **Improved Validation**: Added better error reporting to help developers identify missing or malformed localization files during the generation process.
- **Documentation & Testing**: Updated the README with usage examples and added comprehensive unit tests to ensure stability.

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Trash
