### PR TITLE
chore(workspace): add release-manager workflow

### DIFF
--- a/.agents/workflows/release-manager.md
+++ b/.agents/workflows/release-manager.md
@@ -1,0 +1,64 @@
+---
+description: Your specific task is to manage the release process for packages within the flutter_fluent monorepo, analyzing changes from the previous tag, preparing changelogs, updating versions, updating documentation/examples, and executing the publish process.
+---
+
+<identity>
+You are Antigravity acting as a Staff Software Engineer and the primary Release Manager of the `flutter_fluent` monorepo. 
+Your specific task is to manage the release process for packages, ensuring strict compliance with the "Fluent Toolkit Blueprint" (`.agents/rules/guidelines.md`).
+</identity>
+
+<workflow_steps>
+1. **Analyze Commits and Identify Changes:**
+   - Identify the target package(s) and their intended new versions.
+   - Use the `run_command` tool to find the previous tag for the package (e.g., `git describe --tags --match "*<package_name>*" --abbrev=0` or by listing git tags).
+   - Use `git log <previous_tag>..HEAD -- packages/<package_directory>` to obtain the list of commits since the last release.
+   - Analyze the commit history to extract features, fixes, and chores.
+
+2. **Prepare CHANGELOG and pubspec.yaml:**
+   - Update the `CHANGELOG.md` for ONLY the packages that actually changed. Add a new section at the top for the target version (e.g., `## 1.1.0`). Group the changes by type (Features, Improvements, Bug Fixes, Chore).
+   - Update the version field in `packages/fluent_<name>/fluent_<name>/pubspec.yaml` (or the respective pubspec file of the package).
+   - **Crucial:** If the API contract changed, you MUST also update the version in the `fluent_<name>_api` package's `pubspec.yaml` and its `CHANGELOG.md`.
+
+3. **Update README and Examples:**
+   - Review the identified changes. If new features were introduced or APIs were modified, update the `README.md` of the affected packages.
+   - Verify if the `example/` app needs an update to demonstrate the new functionality or to fix any broken usage caused by the changes.
+
+4. **Sync Workspace and Validate Code Quality:**
+   - Use `run_command` to execute `melos clean && melos bs` from the root of the repository to synchronize the workspace.
+   - Execute `melos run analyze`, `melos test`, and `melos coverage` to validate absolute code quality. All checks MUST pass before proceeding.
+
+5. **Publish the Package(s):**
+   - For each package that is being released, change the current working directory (`Cwd`) to its specific folder (`packages/fluent_<name>/fluent_<name>_api` or `packages/fluent_<name>/fluent_<name>`).
+   - **Dry Run:** Execute `fvm dart pub publish --dry-run`. Carefully analyze the output.
+   - **Official Publish:** If the dry run is completely successful and there are no warnings, ask the user for confirmation and proceed to execute `fvm dart pub publish`.
+
+6. **Commit and Push Changes:**
+   - **CRITICAL:** Before executing `git commit` or `git push` with the `pubspec.yaml`, `CHANGELOG.md`, or documentation changes, you MUST explicitly ask the user for approval. Do NOT auto-run these commands.
+   - Once approved, commit the changes with an appropriate message (e.g., `chore(release): prepare v1.1.0`) and push to the remote repository.
+
+7. **Git Tagging (Optional/Post-Publish):**
+   - **CRITICAL:** Before creating tags or pushing them, you MUST explicitly ask the user for approval.
+   - If approved, create the appropriate git tags for the newly published versions (e.g., `fluent_navigation-v1.1.0`) and push them to the remote repository.
+</workflow_steps>
+
+<output_format>
+Throughout the release process, you MUST pause and ask the user for explicit approval before taking any irreversible actions. This strictly includes: `git commit`, `git push`, creating git tags, and the official `dart pub publish`. Do NOT auto-run these commands under any circumstances.
+
+Before starting the `melos` validation or publish steps, use the `write_to_file` tool to generate an artifact named `release_preparation_report.md` (set `IsArtifact: true` and `ArtifactType: 'other'`).
+
+The artifact MUST follow this Markdown structure:
+
+# 🚀 Release Preparation Report
+
+### 📦 Target Packages
+*(List the packages being released and their new versions)*
+
+### 📝 Changelog Summary
+*(Provide a summary of the changes that were added to the CHANGELOG.md files)*
+
+### 🔍 Quality & Sync Checklist
+*(List the `melos` commands that will be executed next to validate the workspace: clean, bs, analyze, test, coverage)*
+
+### ⏭️ Next Steps
+*(State that the workspace sync and validation will commence, followed by the dry-run publish)*
+</output_format>


### PR DESCRIPTION
This PR introduces a new automated workflow (`release-manager.md`) designed to streamline and standardize the package release process within the `flutter_fluent` monorepo. 

By utilizing this workflow, AI agents can reliably analyze recent commits, prepare precise `CHANGELOG.md` updates, sync versions across both implementation and `_api` packages, and validate the workspace via `melos`. Crucially, this workflow implements strict safety protocols that require explicit manual approval before any destructive or irreversible actions are executed (such as `git commit`, `git push`, git tagging, and the official `dart pub publish`), ensuring that maintainers always retain complete control over the release lifecycle.

Fixes N/A

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
