### PR TITLE
chore(release): prepare fluent_navigation v1.7.0

### DIFF
--- a/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+* **Feature**: Added `replaceWith` method to `NavigationApiImpl` to allow replacing the current route without adding it to the history stack.
+
 ## 1.6.9
 
 * **Fix**: Restored architectural stability by decoupling internal route initialization.

--- a/packages/fluent_navigation/fluent_navigation/pubspec.yaml
+++ b/packages/fluent_navigation/fluent_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_navigation
 description: Package that provides a simple way to navigate within your app
-version: 1.6.9
+version: 1.7.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_navigation/fluent_navigation
 


### PR DESCRIPTION
This PR prepares the `fluent_navigation` package for its official `v1.7.0` release. It bumps the version in `pubspec.yaml` and finalizes the `CHANGELOG.md` to accurately reflect the latest feature additions merged into the implementation. 

**Key inclusions for this release:**
* **Feature:** Added the `replaceWith` method to `NavigationApiImpl`, enabling developers to replace the current route dynamically without appending it to the routing history stack.
* Ensures the internal dependency on `fluent_navigation_api` correctly reflects the `^1.2.0` API contract update.

Fixes N/A

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Trash
