### PR TITLE
feat(environment): add runtime environment switching capability

### DIFF
--- a/packages/fluent_environment/fluent_environment/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.8.0
+
+* FEAT: Implemented runtime environment switching in `EnvironmentInspector`.
+* FEAT: Integrated automatic service reconstruction when the environment changes via `registerResetService`.
+* FEAT: Updated `EnvironmentBanner` to reactively update its text and color.
+* FIX: Ensured `EnvironmentInspector` remains accessible via long press even in production environment when `enableInspector` is true.
+* PERF: Improved `EnvironmentInspector` scrollability and layout.
+* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
+
 ## 0.7.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.7.0`.

--- a/packages/fluent_environment/fluent_environment/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment/CHANGELOG.md
@@ -3,7 +3,7 @@
 * FEAT: Implemented runtime environment switching in `EnvironmentInspector`.
 * FEAT: Integrated automatic service reconstruction when the environment changes via `registerResetService`.
 * FEAT: Updated `EnvironmentBanner` to reactively update its text and color.
-* FIX: Ensured `EnvironmentInspector` remains accessible via long press even in production environment when `enableInspector` is true.
+* FIX: Ensured `EnvironmentBanner` and its inspector trigger remain visible in debug mode even for production environment, hiding them only in release mode.
 * PERF: Improved `EnvironmentInspector` scrollability and layout.
 * CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
 

--- a/packages/fluent_environment/fluent_environment/example/lib/app_environment.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/app_environment.dart
@@ -10,10 +10,10 @@ class DevEnvironment extends Environment {
 
   @override
   Map<String, String> get values => {
-        'url': 'https://dev-api.example.com',
-        'api_key': 'dev-key-123',
-        'debug_mode': 'true',
-      };
+    'url': 'https://dev-api.example.com',
+    'api_key': 'dev-key-123',
+    'debug_mode': 'true',
+  };
 
   @override
   EnvironmentType get type => EnvironmentType.dev;
@@ -28,10 +28,10 @@ class StagingEnvironment extends Environment {
 
   @override
   Map<String, String> get values => {
-        'url': 'https://stg-api.example.com',
-        'api_key': 'stg-key-456',
-        'debug_mode': 'true',
-      };
+    'url': 'https://stg-api.example.com',
+    'api_key': 'stg-key-456',
+    'debug_mode': 'true',
+  };
 
   @override
   EnvironmentType get type => EnvironmentType.stg;
@@ -46,10 +46,10 @@ class ProdEnvironment extends Environment {
 
   @override
   Map<String, String> get values => {
-        'url': 'https://api.example.com',
-        'api_key': 'prod-key-789',
-        'debug_mode': 'false',
-      };
+    'url': 'https://api.example.com',
+    'api_key': 'prod-key-789',
+    'debug_mode': 'false',
+  };
 
   @override
   EnvironmentType get type => EnvironmentType.prod;

--- a/packages/fluent_environment/fluent_environment/example/lib/app_environment.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/app_environment.dart
@@ -1,23 +1,56 @@
 import 'package:fluent_environment/fluent_environment.dart';
 import 'package:flutter/material.dart';
 
-class AppEnvironment extends Environment {
+class DevEnvironment extends Environment {
   @override
-  final String name = "Development";
+  String get name => "Development";
 
   @override
-  final Color color = Colors.blue;
+  Color get color => Colors.blue;
 
   @override
   Map<String, String> get values => {
-    'url': const String.fromEnvironment(
-      'URL',
-      defaultValue: 'https://api.example.com',
-    ),
-    'api_key': 'abc-123-def-456',
-    'debug_mode': 'true',
-  };
+        'url': 'https://dev-api.example.com',
+        'api_key': 'dev-key-123',
+        'debug_mode': 'true',
+      };
 
   @override
   EnvironmentType get type => EnvironmentType.dev;
+}
+
+class StagingEnvironment extends Environment {
+  @override
+  String get name => "Staging";
+
+  @override
+  Color get color => Colors.orange;
+
+  @override
+  Map<String, String> get values => {
+        'url': 'https://stg-api.example.com',
+        'api_key': 'stg-key-456',
+        'debug_mode': 'true',
+      };
+
+  @override
+  EnvironmentType get type => EnvironmentType.stg;
+}
+
+class ProdEnvironment extends Environment {
+  @override
+  String get name => "Production";
+
+  @override
+  Color get color => Colors.green;
+
+  @override
+  Map<String, String> get values => {
+        'url': 'https://api.example.com',
+        'api_key': 'prod-key-789',
+        'debug_mode': 'false',
+      };
+
+  @override
+  EnvironmentType get type => EnvironmentType.prod;
 }

--- a/packages/fluent_environment/fluent_environment/example/lib/main.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/main.dart
@@ -12,7 +12,7 @@ void main() async {
         StagingEnvironment(),
         ProdEnvironment(),
       ],
-    )
+    ),
   ]);
 
   runApp(const MainApp());

--- a/packages/fluent_environment/fluent_environment/example/lib/main.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/main.dart
@@ -4,7 +4,16 @@ import 'package:flutter/material.dart';
 import 'app_environment.dart';
 
 void main() async {
-  await Fluent.build([EnvironmentModule(environment: AppEnvironment())]);
+  await Fluent.build([
+    EnvironmentModule(
+      environment: DevEnvironment(),
+      availableEnvironments: [
+        DevEnvironment(),
+        StagingEnvironment(),
+        ProdEnvironment(),
+      ],
+    )
+  ]);
 
   runApp(const MainApp());
 }
@@ -36,19 +45,27 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final environment = Fluent.get<EnvironmentApi>().environment;
-
     return Scaffold(
       appBar: AppBar(title: const Text('Fluent Environment')),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text("Environment: ${environment.name}"),
+            ValueListenableBuilder<Environment>(
+              valueListenable: Fluent.get<EnvironmentApi>().environmentNotifier,
+              builder: (context, environment, _) {
+                return Text("Current Environment: ${environment.name}");
+              },
+            ),
             const SizedBox(height: 16),
             const Text(
               "Long press the environment banner to see the inspector",
               style: TextStyle(color: Colors.grey),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              "You can now switch environments inside the inspector!",
+              style: TextStyle(color: Colors.blue),
             ),
             const SizedBox(height: 32),
             ElevatedButton(

--- a/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
@@ -1,5 +1,6 @@
 import 'package:fluent_environment/src/widgets/environment_inspector.dart';
 import 'package:fluent_environment_api/fluent_environment_api.dart';
+import 'package:fluent_sdk/fluent_sdk.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -7,9 +8,12 @@ class EnvironmentApiImpl extends EnvironmentApi {
   EnvironmentApiImpl(
     Environment environment,
     this.availableEnvironments,
+    this.registry,
   ) : _environmentNotifier = ValueNotifier(environment);
 
   final ValueNotifier<Environment> _environmentNotifier;
+  final Registry registry;
+  final List<void Function()> _resetters = [];
 
   @override
   final List<Environment> availableEnvironments;
@@ -23,6 +27,14 @@ class EnvironmentApiImpl extends EnvironmentApi {
   @override
   void updateEnvironment(Environment environment) {
     _environmentNotifier.value = environment;
+    for (final reset in _resetters) {
+      reset();
+    }
+  }
+
+  @override
+  void registerResetService<T extends Object>() {
+    _resetters.add(() => registry.resetLazySingleton<T>());
   }
 
   @override

--- a/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
@@ -1,14 +1,29 @@
 import 'package:fluent_environment/src/widgets/environment_inspector.dart';
 import 'package:fluent_environment_api/fluent_environment_api.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class EnvironmentApiImpl extends EnvironmentApi {
-  EnvironmentApiImpl(this._environment);
+  EnvironmentApiImpl(
+    Environment environment,
+    this.availableEnvironments,
+  ) : _environmentNotifier = ValueNotifier(environment);
 
-  final Environment _environment;
+  final ValueNotifier<Environment> _environmentNotifier;
 
   @override
-  Environment get environment => _environment;
+  final List<Environment> availableEnvironments;
+
+  @override
+  Environment get environment => _environmentNotifier.value;
+
+  @override
+  ValueListenable<Environment> get environmentNotifier => _environmentNotifier;
+
+  @override
+  void updateEnvironment(Environment environment) {
+    _environmentNotifier.value = environment;
+  }
 
   @override
   Future<void> showInspector(
@@ -25,7 +40,7 @@ class EnvironmentApiImpl extends EnvironmentApi {
       showDragHandle: true,
       builder: (context) {
         return EnvironmentInspector(
-          environment: _environment,
+          environmentApi: this,
           configValuesLabel: configValuesLabel ?? 'Configuration Values',
           noValuesLabel: noValuesLabel ?? 'No configuration values defined.',
         );

--- a/packages/fluent_environment/fluent_environment/lib/src/environment_module.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/environment_module.dart
@@ -6,16 +6,23 @@ import 'package:fluent_sdk/fluent_sdk.dart';
 class EnvironmentModule extends FluentModule {
   const EnvironmentModule({
     required this.environment,
+    this.availableEnvironments = const [],
   });
 
   final Environment environment;
+  final List<Environment> availableEnvironments;
 
   @override
   void onCreate(Registry registry) {
     registry
-      ..registerLazySingleton<Environment>((_) => environment)
       ..registerLazySingleton<EnvironmentApi>(
-        (it) => EnvironmentApiImpl(it<Environment>()),
-      );
+        (it) => EnvironmentApiImpl(
+          environment,
+          availableEnvironments.isEmpty
+              ? [environment]
+              : availableEnvironments,
+        ),
+      )
+      ..registerFactory<Environment>((it) => it<EnvironmentApi>().environment);
   }
 }

--- a/packages/fluent_environment/fluent_environment/lib/src/environment_module.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/environment_module.dart
@@ -7,21 +7,32 @@ class EnvironmentModule extends FluentModule {
   const EnvironmentModule({
     required this.environment,
     this.availableEnvironments = const [],
+    this.resetServices = const [],
   });
 
   final Environment environment;
   final List<Environment> availableEnvironments;
+  final List<void Function(EnvironmentApi)> resetServices;
 
   @override
   void onCreate(Registry registry) {
     registry
       ..registerLazySingleton<EnvironmentApi>(
-        (it) => EnvironmentApiImpl(
-          environment,
-          availableEnvironments.isEmpty
-              ? [environment]
-              : availableEnvironments,
-        ),
+        (it) {
+          final api = EnvironmentApiImpl(
+            environment,
+            availableEnvironments.isEmpty
+                ? [environment]
+                : availableEnvironments,
+            it,
+          );
+
+          for (final resetService in resetServices) {
+            resetService(api);
+          }
+
+          return api;
+        },
       )
       ..registerFactory<Environment>((it) => it<EnvironmentApi>().environment);
   }

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:fluent_environment_api/fluent_environment_api.dart';
 import 'package:fluent_sdk/fluent_sdk.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// A widget that displays an environment banner if
@@ -71,13 +72,13 @@ class EnvironmentBanner extends StatelessWidget {
       builder: (context, currentEnvironment, _) {
         final env = environment ?? currentEnvironment;
 
-        if (env.isProduction && !enableInspector) {
+        if (kReleaseMode && env.isProduction && !enableInspector) {
           return child;
         }
 
         var content = child;
 
-        if (!env.isProduction) {
+        if (!kReleaseMode || !env.isProduction) {
           content = Banner(
             color: env.color,
             message: env.name,

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -71,24 +71,29 @@ class EnvironmentBanner extends StatelessWidget {
       builder: (context, currentEnvironment, _) {
         final env = environment ?? currentEnvironment;
 
-        if (env.isProduction) {
+        if (env.isProduction && !enableInspector) {
           return child;
         }
 
-        Widget content = Banner(
-          color: env.color,
-          message: env.name,
-          location: location,
-          textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
-          layoutDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
-          textStyle: textStyle ??
-              const TextStyle(
-                fontSize: 10.2,
-                fontWeight: FontWeight.w900,
-                height: 1,
-              ),
-          child: child,
-        );
+        var content = child;
+
+        if (!env.isProduction) {
+          content = Banner(
+            color: env.color,
+            message: env.name,
+            location: location,
+            textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+            layoutDirection:
+                Directionality.maybeOf(context) ?? TextDirection.ltr,
+            textStyle: textStyle ??
+                const TextStyle(
+                  fontSize: 10.2,
+                  fontWeight: FontWeight.w900,
+                  height: 1,
+                ),
+            child: child,
+          );
+        }
 
         if (enableInspector) {
           content = Stack(

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -65,62 +65,67 @@ class EnvironmentBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final envApi = Fluent.get<EnvironmentApi>();
-    final env = environment ?? envApi.environment;
 
-    if (env.isProduction) {
-      return child;
-    }
+    return ValueListenableBuilder<Environment>(
+      valueListenable: envApi.environmentNotifier,
+      builder: (context, currentEnvironment, _) {
+        final env = environment ?? currentEnvironment;
 
-    Widget content = Banner(
-      color: env.color,
-      message: env.name,
-      location: location,
-      textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
-      layoutDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
-      textStyle:
-          textStyle ??
-          const TextStyle(
-            fontSize: 10.2,
-            fontWeight: FontWeight.w900,
-            height: 1,
-          ),
-      child: child,
-    );
+        if (env.isProduction) {
+          return child;
+        }
 
-    if (enableInspector) {
-      content = Stack(
-        children: [
-          content,
-          Positioned.fill(
-            child: Align(
-              alignment: _getAlignmentFromLocation(location),
-              child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
-                onLongPress: () {
-                  unawaited(
-                    envApi.showInspector(
-                      context,
-                      configValuesLabel: configValuesLabel,
-                      noValuesLabel: noValuesLabel,
-                      navigatorKey: navigatorKey,
+        Widget content = Banner(
+          color: env.color,
+          message: env.name,
+          location: location,
+          textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+          layoutDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+          textStyle: textStyle ??
+              const TextStyle(
+                fontSize: 10.2,
+                fontWeight: FontWeight.w900,
+                height: 1,
+              ),
+          child: child,
+        );
+
+        if (enableInspector) {
+          content = Stack(
+            children: [
+              content,
+              Positioned.fill(
+                child: Align(
+                  alignment: _getAlignmentFromLocation(location),
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onLongPress: () {
+                      unawaited(
+                        envApi.showInspector(
+                          context,
+                          configValuesLabel: configValuesLabel,
+                          noValuesLabel: noValuesLabel,
+                          navigatorKey: navigatorKey,
+                        ),
+                      );
+                    },
+                    child: const SizedBox(
+                      width: 80,
+                      height: 80,
                     ),
-                  );
-                },
-                child: const SizedBox(
-                  width: 80,
-                  height: 80,
+                  ),
                 ),
               ),
-            ),
-          ),
-        ],
-      );
-    }
+            ],
+          );
+        }
 
-    return Semantics(
-      label: 'Environment: ${env.name}',
-      container: true,
-      child: content,
+        return Semantics(
+          label: 'Environment: ${env.name}',
+          container: true,
+          child: content,
+        );
+      },
     );
   }
 

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -86,7 +86,8 @@ class EnvironmentBanner extends StatelessWidget {
             textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
             layoutDirection:
                 Directionality.maybeOf(context) ?? TextDirection.ltr,
-            textStyle: textStyle ??
+            textStyle:
+                textStyle ??
                 const TextStyle(
                   fontSize: 10.2,
                   fontWeight: FontWeight.w900,

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -41,101 +41,102 @@ class EnvironmentInspector extends StatelessWidget {
 
           return Container(
             padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Container(
-                      width: 12,
-                      height: 12,
-                      decoration: BoxDecoration(
-                        color: environment.color,
-                        shape: BoxShape.circle,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Container(
+                        width: 12,
+                        height: 12,
+                        decoration: BoxDecoration(
+                          color: environment.color,
+                          shape: BoxShape.circle,
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      environment.name,
-                      style: theme.textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const Spacer(),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 4,
-                      ),
-                      decoration: BoxDecoration(
-                        color: colorScheme.surfaceContainerHighest,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Text(
-                        environment.type.name.toUpperCase(),
-                        style: TextStyle(
-                          fontSize: 10,
-                          color: colorScheme.onSurfaceVariant,
+                      const SizedBox(width: 8),
+                      Text(
+                        environment.name,
+                        style: theme.textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.bold,
                         ),
                       ),
+                      const Spacer(),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
+                        decoration: BoxDecoration(
+                          color: colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          environment.type.name.toUpperCase(),
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: colorScheme.onSurfaceVariant,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const Divider(height: 24),
+                  if (environmentApi.availableEnvironments.length > 1) ...[
+                    Text(
+                      'Available Environments',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
+                    const SizedBox(height: 8),
+                    SizedBox(
+                      height: 40,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: environmentApi.availableEnvironments.length,
+                        separatorBuilder: (context, index) =>
+                            const SizedBox(width: 8),
+                        itemBuilder: (context, index) {
+                          final env =
+                              environmentApi.availableEnvironments[index];
+                          final isSelected = env == environment;
+
+                          return ChoiceChip(
+                            label: Text(env.name),
+                            selected: isSelected,
+                            onSelected: (selected) {
+                              if (selected) {
+                                environmentApi.updateEnvironment(env);
+                              }
+                            },
+                          );
+                        },
+                      ),
+                    ),
+                    const Divider(height: 24),
                   ],
-                ),
-                const Divider(height: 24),
-                if (environmentApi.availableEnvironments.length > 1) ...[
                   Text(
-                    'Available Environments',
+                    configValuesLabel,
                     style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    height: 40,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemCount: environmentApi.availableEnvironments.length,
-                      separatorBuilder: (context, index) =>
-                          const SizedBox(width: 8),
-                      itemBuilder: (context, index) {
-                        final env =
-                            environmentApi.availableEnvironments[index];
-                        final isSelected = env == environment;
-
-                        return ChoiceChip(
-                          label: Text(env.name),
-                          selected: isSelected,
-                          onSelected: (selected) {
-                            if (selected) {
-                              environmentApi.updateEnvironment(env);
-                            }
-                          },
-                        );
-                      },
-                    ),
-                  ),
-                  const Divider(height: 24),
-                ],
-                Text(
-                  configValuesLabel,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                if (environment.values.isEmpty)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 24),
-                    child: Center(
-                      child: Text(noValuesLabel),
-                    ),
-                  )
-                else
-                  Flexible(
-                    child: ListView.separated(
+                  const SizedBox(height: 16),
+                  if (environment.values.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      child: Center(
+                        child: Text(noValuesLabel),
+                      ),
+                    )
+                  else
+                    ListView.separated(
                       shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
                       itemCount: environment.values.length,
                       separatorBuilder: (context, index) =>
                           const Divider(height: 1),
@@ -204,8 +205,8 @@ class EnvironmentInspector extends StatelessWidget {
                         );
                       },
                     ),
-                  ),
-              ],
+                ],
+              ),
             ),
           );
         },

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -11,14 +11,14 @@ import 'package:flutter/services.dart';
 class EnvironmentInspector extends StatelessWidget {
   /// Creates an [EnvironmentInspector].
   const EnvironmentInspector({
-    required this.environment,
+    required this.environmentApi,
     this.configValuesLabel = 'Configuration Values',
     this.noValuesLabel = 'No configuration values defined.',
     super.key,
   });
 
-  /// The environment to inspect.
-  final Environment environment;
+  /// The environment API to use.
+  final EnvironmentApi environmentApi;
 
   /// The label for the configuration values section.
   final String configValuesLabel;
@@ -30,142 +30,185 @@ class EnvironmentInspector extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final sensitiveKeys = environment.sensitiveKeys
-        .map((e) => e.toLowerCase())
-        .toSet();
 
     return SafeArea(
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
+      child: ValueListenableBuilder<Environment>(
+        valueListenable: environmentApi.environmentNotifier,
+        builder: (context, environment, _) {
+          final sensitiveKeys = environment.sensitiveKeys
+              .map((e) => e.toLowerCase())
+              .toSet();
+
+          return Container(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Container(
-                  width: 12,
-                  height: 12,
-                  decoration: BoxDecoration(
-                    color: environment.color,
-                    shape: BoxShape.circle,
-                  ),
+                Row(
+                  children: [
+                    Container(
+                      width: 12,
+                      height: 12,
+                      decoration: BoxDecoration(
+                        color: environment.color,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      environment.name,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const Spacer(),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        environment.type.name.toUpperCase(),
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 8),
-                Text(
-                  environment.name,
-                  style: theme.textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const Spacer(),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Text(
-                    environment.type.name.toUpperCase(),
-                    style: TextStyle(
-                      fontSize: 10,
-                      color: colorScheme.onSurfaceVariant,
+                const Divider(height: 24),
+                if (environmentApi.availableEnvironments.length > 1) ...[
+                  Text(
+                    'Available Environments',
+                    style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
                   ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    height: 40,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: environmentApi.availableEnvironments.length,
+                      separatorBuilder: (context, index) =>
+                          const SizedBox(width: 8),
+                      itemBuilder: (context, index) {
+                        final env =
+                            environmentApi.availableEnvironments[index];
+                        final isSelected = env == environment;
+
+                        return ChoiceChip(
+                          label: Text(env.name),
+                          selected: isSelected,
+                          onSelected: (selected) {
+                            if (selected) {
+                              environmentApi.updateEnvironment(env);
+                            }
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  const Divider(height: 24),
+                ],
+                Text(
+                  configValuesLabel,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
+                const SizedBox(height: 16),
+                if (environment.values.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                    child: Center(
+                      child: Text(noValuesLabel),
+                    ),
+                  )
+                else
+                  Flexible(
+                    child: ListView.separated(
+                      shrinkWrap: true,
+                      itemCount: environment.values.length,
+                      separatorBuilder: (context, index) =>
+                          const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final key = environment.values.keys.elementAt(index);
+                        final value = environment.values[key];
+                        final isSensitive = sensitiveKeys.contains(
+                          key.toLowerCase(),
+                        );
+                        final stringValue = isSensitive
+                            ? '***REDACTED***'
+                            : (value ?? 'N/A');
+
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      key,
+                                      style: theme.textTheme.bodySmall
+                                          ?.copyWith(
+                                        color: colorScheme.secondary,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    SelectableText(
+                                      stringValue,
+                                      style:
+                                          theme.textTheme.bodyMedium?.copyWith(
+                                        fontFamily: 'monospace',
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              if (value != null && !isSensitive)
+                                IconButton(
+                                  icon: const Icon(Icons.copy_all, size: 20),
+                                  tooltip: 'Copy "$key" to clipboard',
+                                  onPressed: () {
+                                    unawaited(
+                                      Clipboard.setData(
+                                        ClipboardData(text: stringValue),
+                                      ),
+                                    );
+                                    if (context.mounted) {
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                            'Copied "$key" to clipboard',
+                                          ),
+                                          duration: const Duration(seconds: 2),
+                                        ),
+                                      );
+                                    }
+                                  },
+                                ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                  ),
               ],
             ),
-            const Divider(height: 24),
-            Text(
-              configValuesLabel,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 16),
-            if (environment.values.isEmpty)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                child: Center(
-                  child: Text(noValuesLabel),
-                ),
-              )
-            else
-              Flexible(
-                child: ListView.separated(
-                  shrinkWrap: true,
-                  itemCount: environment.values.length,
-                  separatorBuilder: (context, index) =>
-                      const Divider(height: 1),
-                  itemBuilder: (context, index) {
-                    final key = environment.values.keys.elementAt(index);
-                    final value = environment.values[key];
-                    final isSensitive = sensitiveKeys.contains(
-                      key.toLowerCase(),
-                    );
-                    final stringValue = isSensitive
-                        ? '***REDACTED***'
-                        : (value ?? 'N/A');
-
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 8),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  key,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: colorScheme.secondary,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                                const SizedBox(height: 2),
-                                SelectableText(
-                                  stringValue,
-                                  style: theme.textTheme.bodyMedium?.copyWith(
-                                    fontFamily: 'monospace',
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          if (value != null && !isSensitive)
-                            IconButton(
-                              icon: const Icon(Icons.copy_all, size: 20),
-                              tooltip: 'Copy "$key" to clipboard',
-                              onPressed: () {
-                                unawaited(
-                                  Clipboard.setData(
-                                    ClipboardData(text: stringValue),
-                                  ),
-                                );
-                                if (context.mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(
-                                        'Copied "$key" to clipboard',
-                                      ),
-                                      duration: const Duration(seconds: 2),
-                                    ),
-                                  );
-                                }
-                              },
-                            ),
-                        ],
-                      ),
-                    );
-                  },
-                ),
-              ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -162,17 +162,17 @@ class EnvironmentInspector extends StatelessWidget {
                                       key,
                                       style: theme.textTheme.bodySmall
                                           ?.copyWith(
-                                        color: colorScheme.secondary,
-                                        fontWeight: FontWeight.bold,
-                                      ),
+                                            color: colorScheme.secondary,
+                                            fontWeight: FontWeight.bold,
+                                          ),
                                     ),
                                     const SizedBox(height: 2),
                                     SelectableText(
                                       stringValue,
-                                      style:
-                                          theme.textTheme.bodyMedium?.copyWith(
-                                        fontFamily: 'monospace',
-                                      ),
+                                      style: theme.textTheme.bodyMedium
+                                          ?.copyWith(
+                                            fontFamily: 'monospace',
+                                          ),
                                     ),
                                   ],
                                 ),
@@ -188,8 +188,9 @@ class EnvironmentInspector extends StatelessWidget {
                                       ),
                                     );
                                     if (context.mounted) {
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(
+                                      ScaffoldMessenger.of(
+                                        context,
+                                      ).showSnackBar(
                                         SnackBar(
                                           content: Text(
                                             'Copied "$key" to clipboard',

--- a/packages/fluent_environment/fluent_environment/pubspec.yaml
+++ b/packages/fluent_environment/fluent_environment/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_environment
 description: Package that provides a way to register your environment globally and display it.
-version: 0.7.0
+version: 0.8.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_environment/fluent_environment
 
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  fluent_sdk: ^0.7.0
-  fluent_environment_api: ^0.4.0
+  fluent_sdk: ^0.8.0
+  fluent_environment_api: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/fluent_environment/fluent_environment/test/mocks/registry_mock.dart
+++ b/packages/fluent_environment/fluent_environment/test/mocks/registry_mock.dart
@@ -1,0 +1,4 @@
+import 'package:fluent_sdk/fluent_sdk.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockRegistry extends Mock implements Registry {}

--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fluent_environment/src/api/environment_api_impl.dart';
 import 'package:fluent_environment/src/widgets/environment_inspector.dart';
 import 'package:fluent_environment_api/fluent_environment_api.dart';
@@ -5,12 +7,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../mocks/registry_mock.dart';
+
 class MockEnvironment extends Mock implements Environment {}
 
 void main() {
   test('verify environment getter returns the injected instance', () {
     final mockEnv = MockEnvironment();
-    final api = EnvironmentApiImpl(mockEnv, [mockEnv]);
+    final mockRegistry = MockRegistry();
+    final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
 
     expect(api.environment, equals(mockEnv));
   });
@@ -18,7 +23,12 @@ void main() {
   test('updateEnvironment should update the current environment', () {
     final mockEnv1 = MockEnvironment();
     final mockEnv2 = MockEnvironment();
-    final api = EnvironmentApiImpl(mockEnv1, [mockEnv1, mockEnv2]);
+    final mockRegistry = MockRegistry();
+    final api = EnvironmentApiImpl(
+      mockEnv1,
+      [mockEnv1, mockEnv2],
+      mockRegistry,
+    );
 
     expect(api.environment, equals(mockEnv1));
 
@@ -30,7 +40,12 @@ void main() {
   test('environmentNotifier should emit new environment on update', () {
     final mockEnv1 = MockEnvironment();
     final mockEnv2 = MockEnvironment();
-    final api = EnvironmentApiImpl(mockEnv1, [mockEnv1, mockEnv2]);
+    final mockRegistry = MockRegistry();
+    final api = EnvironmentApiImpl(
+      mockEnv1,
+      [mockEnv1, mockEnv2],
+      mockRegistry,
+    );
     var notified = false;
 
     api.environmentNotifier.addListener(() {
@@ -43,6 +58,22 @@ void main() {
     expect(api.environmentNotifier.value, equals(mockEnv2));
   });
 
+  test('registerResetService should call registry.resetLazySingleton on update',
+      () {
+    final mockEnv1 = MockEnvironment();
+    final mockEnv2 = MockEnvironment();
+    final mockRegistry = MockRegistry();
+    EnvironmentApiImpl(
+      mockEnv1,
+      [mockEnv1, mockEnv2],
+      mockRegistry,
+    )
+      ..registerResetService<String>()
+      ..updateEnvironment(mockEnv2);
+
+    verify(() => mockRegistry.resetLazySingleton<String>()).called(1);
+  });
+
   testWidgets(
     'showInspector should display EnvironmentInspector in bottom sheet',
     (tester) async {
@@ -53,7 +84,8 @@ void main() {
       when(() => mockEnv.values).thenReturn({});
       when(() => mockEnv.sensitiveKeys).thenReturn({});
 
-      final api = EnvironmentApiImpl(mockEnv, [mockEnv]);
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -88,7 +120,8 @@ void main() {
     when(() => mockEnv.sensitiveKeys).thenReturn({});
 
     final navigatorKey = GlobalKey<NavigatorState>();
-    final api = EnvironmentApiImpl(mockEnv, [mockEnv]);
+    final mockRegistry = MockRegistry();
+    final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -97,10 +130,13 @@ void main() {
       ),
     );
 
-    // ignore: unawaited_futures
-    api.showInspector(
-      navigatorKey.currentContext!,
-      navigatorKey: navigatorKey,
+    // The inspector is shown asynchronously, but we don't need to await it
+    // here as we pump the tester afterwards.
+    unawaited(
+      api.showInspector(
+        navigatorKey.currentContext!,
+        navigatorKey: navigatorKey,
+      ),
     );
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));

--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -58,21 +58,23 @@ void main() {
     expect(api.environmentNotifier.value, equals(mockEnv2));
   });
 
-  test('registerResetService should call registry.resetLazySingleton on update',
-      () {
-    final mockEnv1 = MockEnvironment();
-    final mockEnv2 = MockEnvironment();
-    final mockRegistry = MockRegistry();
-    EnvironmentApiImpl(
-      mockEnv1,
-      [mockEnv1, mockEnv2],
-      mockRegistry,
-    )
-      ..registerResetService<String>()
-      ..updateEnvironment(mockEnv2);
+  test(
+    'registerResetService should call registry.resetLazySingleton on update',
+    () {
+      final mockEnv1 = MockEnvironment();
+      final mockEnv2 = MockEnvironment();
+      final mockRegistry = MockRegistry();
+      EnvironmentApiImpl(
+          mockEnv1,
+          [mockEnv1, mockEnv2],
+          mockRegistry,
+        )
+        ..registerResetService<String>()
+        ..updateEnvironment(mockEnv2);
 
-    verify(() => mockRegistry.resetLazySingleton<String>()).called(1);
-  });
+      verify(() => mockRegistry.resetLazySingleton<String>()).called(1);
+    },
+  );
 
   testWidgets(
     'showInspector should display EnvironmentInspector in bottom sheet',

--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -5,25 +5,47 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-// Definimos un Mock local para no depender de otros archivos de prueba
 class MockEnvironment extends Mock implements Environment {}
 
 void main() {
   test('verify environment getter returns the injected instance', () {
-    // Arrange
     final mockEnv = MockEnvironment();
+    final api = EnvironmentApiImpl(mockEnv, [mockEnv]);
 
-    // Act: Inyectamos el mock directamente (Constructor Injection)
-    final api = EnvironmentApiImpl(mockEnv);
-
-    // Assert: Verificamos que la API devuelva exactamente lo que le inyectamos
     expect(api.environment, equals(mockEnv));
+  });
+
+  test('updateEnvironment should update the current environment', () {
+    final mockEnv1 = MockEnvironment();
+    final mockEnv2 = MockEnvironment();
+    final api = EnvironmentApiImpl(mockEnv1, [mockEnv1, mockEnv2]);
+
+    expect(api.environment, equals(mockEnv1));
+
+    api.updateEnvironment(mockEnv2);
+
+    expect(api.environment, equals(mockEnv2));
+  });
+
+  test('environmentNotifier should emit new environment on update', () {
+    final mockEnv1 = MockEnvironment();
+    final mockEnv2 = MockEnvironment();
+    final api = EnvironmentApiImpl(mockEnv1, [mockEnv1, mockEnv2]);
+    var notified = false;
+
+    api.environmentNotifier.addListener(() {
+      notified = true;
+    });
+
+    api.updateEnvironment(mockEnv2);
+
+    expect(notified, isTrue);
+    expect(api.environmentNotifier.value, equals(mockEnv2));
   });
 
   testWidgets(
     'showInspector should display EnvironmentInspector in bottom sheet',
     (tester) async {
-      // Arrange
       final mockEnv = MockEnvironment();
       when(() => mockEnv.name).thenReturn('Test');
       when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
@@ -31,7 +53,7 @@ void main() {
       when(() => mockEnv.values).thenReturn({});
       when(() => mockEnv.sensitiveKeys).thenReturn({});
 
-      final api = EnvironmentApiImpl(mockEnv);
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv]);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -46,12 +68,10 @@ void main() {
         ),
       );
 
-      // Act
       await tester.tap(find.text('Show'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      // Assert
       expect(find.byType(EnvironmentInspector), findsOneWidget);
       expect(find.text('Test'), findsOneWidget);
     },
@@ -60,7 +80,6 @@ void main() {
   testWidgets('showInspector should use navigatorKey if provided', (
     tester,
   ) async {
-    // Arrange
     final mockEnv = MockEnvironment();
     when(() => mockEnv.name).thenReturn('Test');
     when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
@@ -69,7 +88,7 @@ void main() {
     when(() => mockEnv.sensitiveKeys).thenReturn({});
 
     final navigatorKey = GlobalKey<NavigatorState>();
-    final api = EnvironmentApiImpl(mockEnv);
+    final api = EnvironmentApiImpl(mockEnv, [mockEnv]);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -78,17 +97,14 @@ void main() {
       ),
     );
 
-    // Act
     // ignore: unawaited_futures
     api.showInspector(
-      // This context is outside the navigator (root context)
       navigatorKey.currentContext!,
       navigatorKey: navigatorKey,
     );
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
-    // Assert
     expect(find.byType(EnvironmentInspector), findsOneWidget);
   });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/environment_module_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/environment_module_test.dart
@@ -28,7 +28,7 @@ void main() {
       EnvironmentModule(
         environment: mockEnv1,
         availableEnvironments: [mockEnv1, mockEnv2],
-      )
+      ),
     ]);
     addTearDown(Fluent.reset);
 

--- a/packages/fluent_environment/fluent_environment/test/src/environment_module_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/environment_module_test.dart
@@ -17,8 +17,30 @@ void main() {
     expect(Fluent.get<Environment>(), isA<Environment>());
     expect(Fluent.get<EnvironmentApi>(), isA<EnvironmentApiImpl>());
 
-    // Verificamos que la instancia inyectada sea la misma
     expect(Fluent.get<EnvironmentApi>().environment, equals(mockEnv));
+  });
+
+  test('environment module with multiple environments', () async {
+    final mockEnv1 = MockEnvironment();
+    final mockEnv2 = MockEnvironment();
+
+    await Fluent.build([
+      EnvironmentModule(
+        environment: mockEnv1,
+        availableEnvironments: [mockEnv1, mockEnv2],
+      )
+    ]);
+    addTearDown(Fluent.reset);
+
+    final api = Fluent.get<EnvironmentApi>();
+    expect(api.availableEnvironments, containsAll([mockEnv1, mockEnv2]));
+    expect(api.environment, equals(mockEnv1));
+    expect(Fluent.get<Environment>(), equals(mockEnv1));
+
+    api.updateEnvironment(mockEnv2);
+
+    expect(api.environment, equals(mockEnv2));
+    expect(Fluent.get<Environment>(), equals(mockEnv2));
   });
 
   test('EnvironmentModule can be instantiated as const', () {
@@ -32,14 +54,14 @@ class TestEnvironment extends Environment {
   const TestEnvironment();
 
   @override
-  String get name => throw UnimplementedError();
+  String get name => 'Test';
 
   @override
-  Color get color => throw UnimplementedError();
+  Color get color => const Color(0xFF000000);
 
   @override
-  EnvironmentType get type => throw UnimplementedError();
+  EnvironmentType get type => EnvironmentType.dev;
 
   @override
-  Map<String, String> get values => throw UnimplementedError();
+  Map<String, String> get values => {};
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -97,11 +97,13 @@ void main() {
     expect(bannerWidget.location, BannerLocation.topStart);
   });
 
-  testWidgets('should NOT display banner when environment IS prod', (
+  testWidgets('should display banner when environment IS prod in debug mode', (
     tester,
   ) async {
     // Arrange
     when(() => mockEnv.type).thenReturn(EnvironmentType.prod);
+    when(() => mockEnv.name).thenReturn('PROD');
+    when(() => mockEnv.color).thenReturn(Colors.black);
 
     // Act
     await tester.pumpWidget(
@@ -117,7 +119,7 @@ void main() {
     );
 
     // Assert
-    expect(find.byType(Banner), findsNothing);
+    expect(find.byType(Banner), findsOneWidget);
     expect(find.text('Content'), findsOneWidget);
   });
 

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -21,6 +21,9 @@ void main() {
     mockEnv = MockEnvironment();
     mockEnvApi = EnvironmentApiMock();
 
+    when(() => mockEnvApi.environmentNotifier).thenReturn(
+      ValueNotifier(mockEnv),
+    );
     Fluent.mock<EnvironmentApi>(mockEnvApi);
   });
 
@@ -235,5 +238,41 @@ void main() {
     final bannerWidget = tester.widget<Banner>(find.byType(Banner));
     expect(bannerWidget.textDirection, TextDirection.rtl);
     expect(bannerWidget.layoutDirection, TextDirection.rtl);
+  });
+
+  testWidgets('should update when environment changes', (tester) async {
+    // Arrange
+    final notifier = ValueNotifier<Environment>(mockEnv);
+    when(() => mockEnvApi.environmentNotifier).thenReturn(notifier);
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.name).thenReturn('DEV');
+    when(() => mockEnv.color).thenReturn(Colors.red);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: EnvironmentBanner(
+            child: Text('Content'),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.widget<Banner>(find.byType(Banner)).message, 'DEV');
+
+    // Act
+    final mockEnv2 = MockEnvironment();
+    when(() => mockEnv2.type).thenReturn(EnvironmentType.stg);
+    when(() => mockEnv2.name).thenReturn('STG');
+    when(() => mockEnv2.color).thenReturn(Colors.orange);
+
+    notifier.value = mockEnv2;
+    await tester.pump();
+
+    // Assert
+    expect(tester.widget<Banner>(find.byType(Banner)).message, 'STG');
+    final bannerWidget = tester.widget<Banner>(find.byType(Banner));
+    expect(bannerWidget.color, Colors.orange);
   });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockEnvironment extends Mock implements Environment {}
+
 class MockEnvironmentApi extends Mock implements EnvironmentApi {}
 
 void main() {
@@ -55,8 +56,9 @@ void main() {
     expect(find.text('dev_key_123'), findsOneWidget);
   });
 
-  testWidgets('should show environment switcher when multiple environments',
-      (tester) async {
+  testWidgets('should show environment switcher when multiple environments', (
+    tester,
+  ) async {
     final mockEnv2 = MockEnvironment();
     when(() => mockEnv2.name).thenReturn('Staging');
     when(() => mockEnv2.type).thenReturn(EnvironmentType.stg);

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -4,13 +4,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockEnvironment extends Mock implements Environment {}
+class MockEnvironmentApi extends Mock implements EnvironmentApi {}
 
 void main() {
   late MockEnvironment mockEnv;
+  late MockEnvironmentApi mockApi;
+
+  setUpAll(() {
+    registerFallbackValue(MockEnvironment());
+  });
 
   setUp(() {
     mockEnv = MockEnvironment();
+    mockApi = MockEnvironmentApi();
     when(() => mockEnv.sensitiveKeys).thenReturn({});
+    when(() => mockEnv.name).thenReturn('Development');
+    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
+    when(() => mockEnv.color).thenReturn(Colors.blue);
+    when(() => mockEnv.values).thenReturn({});
+    when(() => mockApi.environmentNotifier).thenReturn(ValueNotifier(mockEnv));
+    when(() => mockApi.availableEnvironments).thenReturn([mockEnv]);
   });
 
   testWidgets('should display environment details', (tester) async {
@@ -27,7 +40,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: EnvironmentInspector(environment: mockEnv),
+          body: EnvironmentInspector(environmentApi: mockApi),
         ),
       ),
     );
@@ -42,6 +55,35 @@ void main() {
     expect(find.text('dev_key_123'), findsOneWidget);
   });
 
+  testWidgets('should show environment switcher when multiple environments',
+      (tester) async {
+    final mockEnv2 = MockEnvironment();
+    when(() => mockEnv2.name).thenReturn('Staging');
+    when(() => mockEnv2.type).thenReturn(EnvironmentType.stg);
+    when(() => mockEnv2.color).thenReturn(Colors.orange);
+    when(() => mockEnv2.values).thenReturn({});
+    when(() => mockEnv2.sensitiveKeys).thenReturn({});
+
+    when(() => mockApi.availableEnvironments).thenReturn([mockEnv, mockEnv2]);
+    when(() => mockApi.updateEnvironment(any())).thenReturn(null);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EnvironmentInspector(environmentApi: mockApi),
+        ),
+      ),
+    );
+
+    expect(find.text('Available Environments'), findsOneWidget);
+    expect(find.text('Staging'), findsOneWidget);
+
+    await tester.tap(find.text('Staging'));
+    await tester.pump();
+
+    verify(() => mockApi.updateEnvironment(mockEnv2)).called(1);
+  });
+
   testWidgets('should display empty message when no values', (tester) async {
     // Arrange
     when(() => mockEnv.name).thenReturn('Staging');
@@ -53,7 +95,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: EnvironmentInspector(environment: mockEnv),
+          body: EnvironmentInspector(environmentApi: mockApi),
         ),
       ),
     );
@@ -68,15 +110,12 @@ void main() {
     tester,
   ) async {
     // Arrange
-    when(() => mockEnv.name).thenReturn('Dev');
-    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
-    when(() => mockEnv.color).thenReturn(Colors.blue);
     when(() => mockEnv.values).thenReturn({'key': 'value'});
 
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: EnvironmentInspector(environment: mockEnv),
+          body: EnvironmentInspector(environmentApi: mockApi),
         ),
       ),
     );
@@ -85,25 +124,18 @@ void main() {
     expect(find.byIcon(Icons.copy_all), findsOneWidget);
     await tester.tap(find.byIcon(Icons.copy_all));
 
-    // Trigger the async onPressed and wait for the snackbar animation
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
     // Assert
     expect(find.byType(SnackBar), findsOneWidget);
     expect(find.text('Copied "key" to clipboard'), findsOneWidget);
-
-    final iconButton = tester.widget<IconButton>(find.byType(IconButton));
-    expect(iconButton.tooltip, 'Copy "key" to clipboard');
   });
 
   testWidgets('should redact sensitive keys and hide copy button', (
     tester,
   ) async {
     // Arrange
-    when(() => mockEnv.name).thenReturn('Dev');
-    when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
-    when(() => mockEnv.color).thenReturn(Colors.blue);
     when(() => mockEnv.values).thenReturn({
       'public_key': 'public_123',
       'secret_key': 'secret_456',
@@ -113,7 +145,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: EnvironmentInspector(environment: mockEnv),
+          body: EnvironmentInspector(environmentApi: mockApi),
         ),
       ),
     );
@@ -125,8 +157,6 @@ void main() {
     expect(find.text('secret_456'), findsNothing);
     expect(find.text('***REDACTED***'), findsOneWidget);
 
-    // Copy button should exist for public_key but not for secret_key
-    // In this case, we expect only one copy button in the entire widget
     expect(find.byIcon(Icons.copy_all), findsOneWidget);
   });
 }

--- a/packages/fluent_environment/fluent_environment_api/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment_api/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+* FEAT: Added `environmentNotifier` (ValueListenable) to `EnvironmentApi` for reactive UI updates.
+* FEAT: Added `updateEnvironment` and `availableEnvironments` to support runtime environment switching.
+* FEAT: Added `registerResetService` to allow automatic reconstruction of dependent services (e.g., Networking) when the environment changes.
+
 ## 0.4.0
 
 * **FEAT**: Add `sensitiveKeys` support to `Environment` model.

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
@@ -18,6 +18,12 @@ abstract class EnvironmentApi {
   /// Updates the current environment.
   void updateEnvironment(Environment environment);
 
+  /// Registers a service to be reset whenever the environment changes.
+  ///
+  /// This is useful for services that depend on environment values (like Dio)
+  /// and need to be reconstructed to pick up the new values.
+  void registerResetService<T extends Object>();
+
   /// Shows the environment inspector.
   Future<void> showInspector(
     BuildContext context, {

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
@@ -1,4 +1,5 @@
 import 'package:fluent_environment_api/src/environment.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Interface defined to use the fluent environment functionalities
@@ -7,6 +8,15 @@ abstract class EnvironmentApi {
   ///
   /// A [AssertionError] maybe thrown if there is no any registered environment
   Environment get environment;
+
+  /// The list of available environments.
+  List<Environment> get availableEnvironments;
+
+  /// A notifier that emits the current environment whenever it changes.
+  ValueListenable<Environment> get environmentNotifier;
+
+  /// Updates the current environment.
+  void updateEnvironment(Environment environment);
 
   /// Shows the environment inspector.
   Future<void> showInspector(

--- a/packages/fluent_environment/fluent_environment_api/pubspec.yaml
+++ b/packages/fluent_environment/fluent_environment_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_environment_api
 description: A common interface for the fluent_environment package.
-version: 0.4.0
+version: 0.5.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_environment/fluent_environment_api
 

--- a/packages/fluent_localization/fluent_localization/CHANGELOG.md
+++ b/packages/fluent_localization/fluent_localization/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.2
+## 1.9.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
 

--- a/packages/fluent_localization/fluent_localization/CHANGELOG.md
+++ b/packages/fluent_localization/fluent_localization/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.2
+
+* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
+
 ## 1.8.1
 
 * PERF: Optimized recursive string flattening and map processing.

--- a/packages/fluent_localization/fluent_localization/pubspec.yaml
+++ b/packages/fluent_localization/fluent_localization/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_localization
 description: Package that allows you to set up and use translations in an easy and quick way
-version: 1.8.1
+version: 1.8.2
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_localization/fluent_localization
 
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  fluent_sdk: ^0.7.0
+  fluent_sdk: ^0.8.0
   fluent_localization_api: ^1.0.3
   fluent_logger_api: ^0.0.4
 

--- a/packages/fluent_localization/fluent_localization/pubspec.yaml
+++ b/packages/fluent_localization/fluent_localization/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_localization
 description: Package that allows you to set up and use translations in an easy and quick way
-version: 1.8.2
+version: 1.9.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_localization/fluent_localization
 

--- a/packages/fluent_logger/fluent_logger/CHANGELOG.md
+++ b/packages/fluent_logger/fluent_logger/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.1
+## 0.7.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
 

--- a/packages/fluent_logger/fluent_logger/CHANGELOG.md
+++ b/packages/fluent_logger/fluent_logger/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
+
 ## 0.6.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.7.0`.

--- a/packages/fluent_logger/fluent_logger/pubspec.yaml
+++ b/packages/fluent_logger/fluent_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_fluent_logger
 description: Package that allows you to print different types of messages in console
-version: 0.6.0
+version: 0.6.1
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_logger/fluent_logger
 
@@ -8,7 +8,7 @@ environment:
   sdk: '^3.9.2'
 
 dependencies:
-  fluent_sdk: ^0.7.0
+  fluent_sdk: ^0.8.0
   fluent_logger_api: ^0.0.5
   loggy: ^2.0.3
 

--- a/packages/fluent_logger/fluent_logger/pubspec.yaml
+++ b/packages/fluent_logger/fluent_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_fluent_logger
 description: Package that allows you to print different types of messages in console
-version: 0.6.1
+version: 0.7.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_logger/fluent_logger
 

--- a/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.1
+## 1.9.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
 

--- a/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1
+
+* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
+
 ## 1.8.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.7.0`.

--- a/packages/fluent_navigation/fluent_navigation/pubspec.yaml
+++ b/packages/fluent_navigation/fluent_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_navigation
 description: Package that provides a simple way to navigate within your app
-version: 1.8.1
+version: 1.9.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_navigation/fluent_navigation
 

--- a/packages/fluent_navigation/fluent_navigation/pubspec.yaml
+++ b/packages/fluent_navigation/fluent_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_navigation
 description: Package that provides a simple way to navigate within your app
-version: 1.8.0
+version: 1.8.1
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_navigation/fluent_navigation
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  fluent_sdk: ^0.7.0
+  fluent_sdk: ^0.8.0
   fluent_navigation_api: ^1.2.0
   go_router: ^17.0.1
   collection: ^1.19.1

--- a/packages/fluent_networking/fluent_networking/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking/CHANGELOG.md
@@ -4,6 +4,7 @@
 * SECURITY: Expanded default sensitive keys for headers, query params, and body (including email, phone_number, and credit_card).
 * PERF: Optimized sensitive key checking for `FormData` fields.
 * PERF: Further optimized `NetworkingLogInterceptor` map processing and reduced allocations.
+* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
 
 ## 0.7.0
 

--- a/packages/fluent_networking/fluent_networking/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking/CHANGELOG.md
@@ -1,10 +1,13 @@
+## 0.9.0
+
+* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
+
 ## 0.8.0
 
 * FEAT: Add support for `FormData` sanitization in log interceptor.
 * SECURITY: Expanded default sensitive keys for headers, query params, and body (including email, phone_number, and credit_card).
 * PERF: Optimized sensitive key checking for `FormData` fields.
 * PERF: Further optimized `NetworkingLogInterceptor` map processing and reduced allocations.
-* CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.
 
 ## 0.7.0
 

--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -289,12 +289,7 @@ class NetworkingLogInterceptor extends Interceptor {
 
   void _log(Iterable<String> lines) {
     if (_logger == null) return;
-    // Using for-in to avoid closure allocation, although linter prefers forEach
-    // with tear-offs.
-    // ignore: prefer_foreach
-    for (final line in lines) {
-      _logger.logInfo(line);
-    }
+    lines.forEach(_logger.logInfo);
   }
 
   void _logError(Iterable<String> lines, {StackTrace? stackTrace}) {

--- a/packages/fluent_networking/fluent_networking/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '^3.9.2'
 
 dependencies:
-  fluent_sdk: ^0.7.0
+  fluent_sdk: ^0.8.0
   fluent_networking_api: ^0.4.0
   fluent_logger_api: ^0.0.4
   dio: ^5.9.1

--- a/packages/fluent_networking/fluent_networking/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_networking
 description: Package that provides a simple way to make http requests
-version: 0.8.0
+version: 0.9.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_networking/fluent_networking
 

--- a/packages/fluent_sdk/CHANGELOG.md
+++ b/packages/fluent_sdk/CHANGELOG.md
@@ -64,6 +64,10 @@
 * CHORE: Recreated example platforms and updated READMEs.
 * FEAT: Added `onStart` and `onStop` lifecycle methods to `FluentModule`.
 
+## 0.8.0
+
+* FEAT: Added `resetLazySingleton` and `unregister` methods to `Registry` interface to support dynamic dependency management.
+
 ## 0.7.0
 
 * FIX: Added missing `call` and `get` methods to `Registry` interface.

--- a/packages/fluent_sdk/lib/src/api/registry.dart
+++ b/packages/fluent_sdk/lib/src/api/registry.dart
@@ -30,7 +30,7 @@ abstract class Registry {
   });
 
   /// Checks if a type [T] is currently registered in the container.
-  bool isRegistered<T extends Object>();
+  bool isRegistered<T extends Object>({String? instanceName});
 
   /// Retrieves an instance of a registered object [T].
   T get<T extends Object>({String? instanceName});

--- a/packages/fluent_sdk/lib/src/api/registry.dart
+++ b/packages/fluent_sdk/lib/src/api/registry.dart
@@ -37,4 +37,18 @@ abstract class Registry {
 
   /// Retrieves an instance of a registered object [T] (shorthand for [get]).
   T call<T extends Object>({String? instanceName});
+
+  /// Resets a Lazy Singleton, allowing it to be recreated on the next request.
+  void resetLazySingleton<T extends Object>({
+    T? instance,
+    String? instanceName,
+    void Function(T)? disposingFunction,
+  });
+
+  /// Unregisters an instance of a registered object [T].
+  void unregister<T extends Object>({
+    T? instance,
+    String? instanceName,
+    void Function(T)? disposingFunction,
+  });
 }

--- a/packages/fluent_sdk/lib/src/fluent_registry.dart
+++ b/packages/fluent_sdk/lib/src/fluent_registry.dart
@@ -15,7 +15,8 @@ class FluentRegistry implements Registry {
 
   @override
   @pragma('vm:prefer-inline')
-  bool isRegistered<T extends Object>() => _getIt.isRegistered<T>();
+  bool isRegistered<T extends Object>({String? instanceName}) =>
+      _getIt.isRegistered<T>(instanceName: instanceName);
 
   @override
   @pragma('vm:prefer-inline')

--- a/packages/fluent_sdk/lib/src/fluent_registry.dart
+++ b/packages/fluent_sdk/lib/src/fluent_registry.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fluent_sdk/fluent_sdk.dart';
 import 'package:get_it/get_it.dart';
 
@@ -59,5 +61,39 @@ class FluentRegistry implements Registry {
       factoryFunction(this),
       instanceName: instanceName,
     );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  void resetLazySingleton<T extends Object>({
+    T? instance,
+    String? instanceName,
+    void Function(T)? disposingFunction,
+  }) {
+    final result = _getIt.resetLazySingleton<T>(
+      instance: instance,
+      instanceName: instanceName,
+      disposingFunction: disposingFunction,
+    );
+    if (result is Future<void>) {
+      unawaited(result);
+    }
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  void unregister<T extends Object>({
+    T? instance,
+    String? instanceName,
+    void Function(T)? disposingFunction,
+  }) {
+    final result = _getIt.unregister<T>(
+      instance: instance,
+      instanceName: instanceName,
+      disposingFunction: disposingFunction,
+    );
+    if (result is Future<void>) {
+      unawaited(result);
+    }
   }
 }

--- a/packages/fluent_sdk/pubspec.yaml
+++ b/packages/fluent_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_sdk
 description: Package that provide a way to modularize features through a service locator.
-version: 0.7.0
+version: 0.8.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_sdk
 

--- a/packages/fluent_sdk/test/src/fluent_registry_test.dart
+++ b/packages/fluent_sdk/test/src/fluent_registry_test.dart
@@ -77,5 +77,61 @@ void main() {
 
       expect(GetIt.instance<TestClass2>(), isA<TestClass2>());
     });
+
+    test('resetLazySingleton should reset the instance', () {
+      var count = 0;
+      registry.registerLazySingleton<TestClass>((_) {
+        count++;
+        return TestClass();
+      });
+
+      final instance1 = registry.get<TestClass>();
+      expect(count, 1);
+
+      registry.resetLazySingleton<TestClass>(instance: instance1);
+
+      registry.get<TestClass>();
+      expect(count, 2);
+    });
+
+    test('unregister should remove the registration', () {
+      registry.registerSingleton<TestClass>((_) => TestClass());
+      expect(registry.isRegistered<TestClass>(), isTrue);
+
+      registry.unregister<TestClass>();
+
+      expect(registry.isRegistered<TestClass>(), isFalse);
+    });
+
+    test('resetLazySingleton should handle async disposing function', () async {
+      registry.registerLazySingleton<TestClass>((_) => TestClass());
+      registry.get<TestClass>();
+
+      registry.resetLazySingleton<TestClass>(
+        disposingFunction: (_) => Future.delayed(Duration.zero),
+      );
+    });
+
+    test('resetLazySingleton and unregister with instanceName', () {
+      registry.registerLazySingleton<TestClass>(
+        (_) => TestClass(),
+        instanceName: 'test',
+      );
+
+      expect(registry.isRegistered<TestClass>(instanceName: 'test'), isTrue);
+
+      registry.resetLazySingleton<TestClass>(instanceName: 'test');
+      registry.unregister<TestClass>(instanceName: 'test');
+
+      expect(registry.isRegistered<TestClass>(instanceName: 'test'), isFalse);
+    });
+
+    test('unregister should handle async disposing function', () async {
+      registry.registerSingleton<TestClass>((_) => TestClass());
+
+      registry.unregister<TestClass>(
+        disposingFunction: (_) => Future.delayed(Duration.zero),
+      );
+    });
   });
 }

--- a/packages/fluent_sdk/test/src/fluent_registry_test.dart
+++ b/packages/fluent_sdk/test/src/fluent_registry_test.dart
@@ -88,9 +88,9 @@ void main() {
       final instance1 = registry.get<TestClass>();
       expect(count, 1);
 
-      registry.resetLazySingleton<TestClass>(instance: instance1);
-
-      registry.get<TestClass>();
+      registry
+        ..resetLazySingleton<TestClass>(instance: instance1)
+        ..get<TestClass>();
       expect(count, 2);
     });
 
@@ -98,18 +98,19 @@ void main() {
       registry.registerSingleton<TestClass>((_) => TestClass());
       expect(registry.isRegistered<TestClass>(), isTrue);
 
-      registry.unregister<TestClass>();
-
+      registry
+        ..unregister<TestClass>()
+        ..isRegistered<TestClass>();
       expect(registry.isRegistered<TestClass>(), isFalse);
     });
 
     test('resetLazySingleton should handle async disposing function', () async {
-      registry.registerLazySingleton<TestClass>((_) => TestClass());
-      registry.get<TestClass>();
-
-      registry.resetLazySingleton<TestClass>(
-        disposingFunction: (_) => Future.delayed(Duration.zero),
-      );
+      registry
+        ..registerLazySingleton<TestClass>((_) => TestClass())
+        ..get<TestClass>()
+        ..resetLazySingleton<TestClass>(
+          disposingFunction: (_) => Future<void>.delayed(Duration.zero),
+        );
     });
 
     test('resetLazySingleton and unregister with instanceName', () {
@@ -120,18 +121,19 @@ void main() {
 
       expect(registry.isRegistered<TestClass>(instanceName: 'test'), isTrue);
 
-      registry.resetLazySingleton<TestClass>(instanceName: 'test');
-      registry.unregister<TestClass>(instanceName: 'test');
+      registry
+        ..resetLazySingleton<TestClass>(instanceName: 'test')
+        ..unregister<TestClass>(instanceName: 'test');
 
       expect(registry.isRegistered<TestClass>(instanceName: 'test'), isFalse);
     });
 
     test('unregister should handle async disposing function', () async {
-      registry.registerSingleton<TestClass>((_) => TestClass());
-
-      registry.unregister<TestClass>(
-        disposingFunction: (_) => Future.delayed(Duration.zero),
-      );
+      registry
+        ..registerSingleton<TestClass>((_) => TestClass())
+        ..unregister<TestClass>(
+          disposingFunction: (_) => Future<void>.delayed(Duration.zero),
+        );
     });
   });
 }


### PR DESCRIPTION
### Description
This PR introduces **Runtime Environment Switching** to the `fluent_environment` package. Previously, environments were static and registered once during application startup. With this update, developers can register multiple environments and switch between them at runtime via the `EnvironmentInspector`.

### Why this is valuable:
- **Developer & QA Efficiency:** Instantly toggle between Dev, Staging, and Production configurations within the app without needing to rebuild or use external tools.
- **Reactive UI:** The `EnvironmentBanner` and any component depending on the current `Environment` will update automatically when the environment changes.
- **Improved Inspection:** The `EnvironmentInspector` now includes a horizontal switcher to easily select from the available environments.

### Changes:
- **`fluent_environment_api`**: Added `availableEnvironments`, `updateEnvironment`, and `environmentNotifier` to the `EnvironmentApi` interface.
- **`fluent_environment`**:
    - `EnvironmentApiImpl` now manages the active environment using a `ValueNotifier`.
    - `EnvironmentModule` supports registering a list of available environments and registers the `Environment` type as a dynamic factory for monorepo-wide reactivity.
    - `EnvironmentInspector` features a new "Available Environments" section.
    - `EnvironmentBanner` is now reactive to environment changes.
- **Tests**: Comprehensive unit and widget tests added to verify switching logic and UI reactivity.
- **Example**: Updated the example app to demonstrate switching between Dev, Staging, and Production.

---
*PR created automatically by Jules for task [17952205071683408320](https://jules.google.com/task/17952205071683408320) started by @aosorio-avilez*