### PR TITLE
style(environment): enhance accessibility and ux of environment widgets

### DIFF
--- a/packages/fluent_environment/fluent_environment/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.8.1
+
+* FEAT: Added standard Close button (`IconButton` with cross icon) to `EnvironmentInspector`.
+* FEAT: Added accessibility semantics (`onLongPressHint`, labels, and `Sensitive configuration value` semantics) to both `EnvironmentBanner` and `EnvironmentInspector`.
+* FEAT: Colored sensitive configurations with the theme's error color in the inspector.
+* TEST: Enhanced tests for semantic elements and copy buttons under sensitive configurations.
+
 ## 0.8.0
 
 * FEAT: Implemented runtime environment switching in `EnvironmentInspector`.

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -130,6 +130,9 @@ class EnvironmentBanner extends StatelessWidget {
         return Semantics(
           label: 'Environment: ${env.name}',
           container: true,
+          onLongPressHint: enableInspector
+              ? 'Long press to open environment inspector'
+              : null,
           child: content,
         );
       },

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -48,12 +48,15 @@ class EnvironmentInspector extends StatelessWidget {
                 children: [
                   Row(
                     children: [
-                      Container(
-                        width: 12,
-                        height: 12,
-                        decoration: BoxDecoration(
-                          color: environment.color,
-                          shape: BoxShape.circle,
+                      Semantics(
+                        label: 'Environment color indicator',
+                        child: Container(
+                          width: 12,
+                          height: 12,
+                          decoration: BoxDecoration(
+                            color: environment.color,
+                            shape: BoxShape.circle,
+                          ),
                         ),
                       ),
                       const SizedBox(width: 8),
@@ -81,6 +84,12 @@ class EnvironmentInspector extends StatelessWidget {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
+                      ),
+                      const SizedBox(width: 8),
+                      IconButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        icon: const Icon(Icons.close),
+                        tooltip: 'Close',
                       ),
                     ],
                   ),
@@ -167,12 +176,20 @@ class EnvironmentInspector extends StatelessWidget {
                                           ),
                                     ),
                                     const SizedBox(height: 2),
-                                    SelectableText(
-                                      stringValue,
-                                      style: theme.textTheme.bodyMedium
-                                          ?.copyWith(
-                                            fontFamily: 'monospace',
-                                          ),
+                                    Semantics(
+                                      label: isSensitive
+                                          ? 'Sensitive configuration value'
+                                          : null,
+                                      child: SelectableText(
+                                        stringValue,
+                                        style: theme.textTheme.bodyMedium
+                                            ?.copyWith(
+                                              fontFamily: 'monospace',
+                                              color: isSensitive
+                                                  ? theme.colorScheme.error
+                                                  : null,
+                                            ),
+                                      ),
                                     ),
                                   ],
                                 ),

--- a/packages/fluent_environment/fluent_environment/pubspec.yaml
+++ b/packages/fluent_environment/fluent_environment/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_environment
 description: Package that provides a way to register your environment globally and display it.
-version: 0.8.0
+version: 0.8.1
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_environment/fluent_environment
 

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_banner_test.dart
@@ -64,7 +64,9 @@ void main() {
     // Check Semantics
     final semanticsFinder = find.byWidgetPredicate(
       (widget) =>
-          widget is Semantics && widget.properties.label == 'Environment: DEV',
+          widget is Semantics &&
+          widget.properties.label == 'Environment: DEV' &&
+          widget.properties.hintOverrides?.onLongPressHint == null,
     );
     expect(semanticsFinder, findsOneWidget);
   });
@@ -152,6 +154,15 @@ void main() {
 
       // Assert
       verify(() => mockEnvApi.showInspector(any())).called(1);
+
+      // Check Semantics
+      final semanticsFinder = find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.hintOverrides?.onLongPressHint ==
+                'Long press to open environment inspector',
+      );
+      expect(semanticsFinder, findsOneWidget);
     },
   );
 

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -181,6 +181,16 @@ void main() {
       findsOneWidget,
     );
 
+    // Assert exactly one copy button exists (associated with public_key)
     expect(find.byIcon(Icons.copy_all), findsOneWidget);
+
+    // Verify that the copy button matches the non-sensitive key
+    final copyIconButton = find.ancestor(
+      of: find.byIcon(Icons.copy_all),
+      matching: find.byType(IconButton),
+    );
+    final tooltip = tester.widget<IconButton>(copyIconButton).tooltip;
+    expect(tooltip, contains('public_key'));
+    expect(tooltip, isNot(contains('secret_key')));
   });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -54,6 +54,20 @@ void main() {
     expect(find.text('https://api.dev.example.com'), findsOneWidget);
     expect(find.text('api_key'), findsOneWidget);
     expect(find.text('dev_key_123'), findsOneWidget);
+
+    // Check Close button
+    expect(find.widgetWithIcon(IconButton, Icons.close), findsOneWidget);
+    expect(find.byTooltip('Close'), findsOneWidget);
+
+    // Check color indicator semantics
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.label == 'Environment color indicator',
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('should show environment switcher when multiple environments', (
@@ -158,6 +172,14 @@ void main() {
     expect(find.text('secret_key'), findsOneWidget);
     expect(find.text('secret_456'), findsNothing);
     expect(find.text('***REDACTED***'), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.label == 'Sensitive configuration value',
+      ),
+      findsOneWidget,
+    );
 
     expect(find.byIcon(Icons.copy_all), findsOneWidget);
   });


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the `fluent_environment` package to make the debugging tools more intuitive and accessible for everyone.

### Changes
- **EnvironmentBanner Accessibility**: Added `onLongPressHint` to the banner's semantics. This informs users using screen readers that they can long-press to open the environment inspector.
- **EnvironmentInspector UX**: Added an explicit **Close button** in the header. While the bottom sheet was already dismissible via gestures, a clear visual button improves discoverability and provides a standard way to exit the inspector.
- **EnvironmentInspector Accessibility**: 
    - Added a semantic label to the environment color indicator circle.
    - Added a descriptive semantic label to redacted sensitive values ("Sensitive configuration value").
- **Visual Feedback**: Redacted values now use the theme's **error color**, making it immediately obvious which pieces of configuration are protected for security.
- **Improved Testing**: Updated widget tests to ensure these new accessibility features and UI elements are correctly implemented and preserved in the future.

### Impact
- Better Developer Experience (DX) when debugging environments.
- Improved Accessibility for users relying on assistive technologies.
- Zero breaking changes to the public API.

---
*PR created automatically by Jules for task [12928431852883432911](https://jules.google.com/task/12928431852883432911) started by @aosorio-avilez*