### PR TITLE
fix(networking): enhance sensitive data redaction in network logs

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -38,11 +38,17 @@ class NetworkingLogInterceptor extends Interceptor {
 
   static const _defaultSensitiveHeaders = {
     'authorization',
+    'authentication',
     'cookie',
     'proxy-authorization',
     'set-cookie',
     'x-api-key',
     'api-key',
+    'x-auth-token',
+    'xsrf-token',
+    'csrf-token',
+    'session-id',
+    'sid',
   };
 
   static const _defaultSensitiveQueryParams = {
@@ -54,6 +60,10 @@ class NetworkingLogInterceptor extends Interceptor {
     'password',
     'pass',
     'pwd',
+    'session_id',
+    'sid',
+    'csrf_token',
+    'xsrf_token',
   };
 
   static const _defaultSensitiveBodyKeys = {
@@ -71,6 +81,10 @@ class NetworkingLogInterceptor extends Interceptor {
     'cvc',
     'email',
     'phone_number',
+    'session_id',
+    'sid',
+    'csrf_token',
+    'xsrf_token',
   };
 
   static const _extraStartTime = 'networking_start_time';
@@ -202,26 +216,66 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   String _sanitizeUri(Uri uri) {
-    if (uri.queryParameters.isEmpty) return uri.toString();
+    var sanitizedUri = uri;
+
+    // Redact userInfo password if present
+    if (sanitizedUri.userInfo.contains(':')) {
+      final userInfoParts = sanitizedUri.userInfo.split(':');
+      final user = userInfoParts.first;
+      sanitizedUri = sanitizedUri.replace(userInfo: '$user:***REDACTED***');
+    }
+
+    // Redact fragment if it contains sensitive keys
+    if (sanitizedUri.hasFragment) {
+      final fragmentParams = Uri.splitQueryString(sanitizedUri.fragment);
+      if (fragmentParams.isNotEmpty) {
+        final sanitizedFragmentParams = <String, String>{};
+        var fragmentChanged = false;
+
+        for (final entry in fragmentParams.entries) {
+          final key = entry.key;
+          final value = entry.value;
+          final isSensitive =
+              _sensitiveQueryParams.contains(key) ||
+              _sensitiveQueryParams.contains(key.toLowerCase());
+
+          if (isSensitive) {
+            sanitizedFragmentParams[key] = '***REDACTED***';
+            fragmentChanged = true;
+          } else {
+            sanitizedFragmentParams[key] = value;
+          }
+        }
+
+        if (fragmentChanged) {
+          final newFragment = sanitizedFragmentParams.entries
+              .map((e) => '${e.key}=${e.value}')
+              .join('&');
+          sanitizedUri = sanitizedUri.replace(fragment: newFragment);
+        }
+      }
+    }
+
+    if (sanitizedUri.queryParameters.isEmpty) return sanitizedUri.toString();
 
     Map<String, dynamic>? queryParameters;
 
-    for (final key in uri.queryParametersAll.keys) {
+    for (final key in sanitizedUri.queryParametersAll.keys) {
       final isSensitive =
           _sensitiveQueryParams.contains(key) ||
           _sensitiveQueryParams.contains(key.toLowerCase());
 
       if (isSensitive) {
         queryParameters ??= Map<String, List<String>>.of(
-          uri.queryParametersAll,
+          sanitizedUri.queryParametersAll,
         );
         queryParameters[key] = ['***REDACTED***'];
       }
     }
 
     return queryParameters != null
-        ? uri.replace(queryParameters: queryParameters).toString()
-        : uri.toString();
+        ? sanitizedUri.replace(queryParameters: queryParameters).toString()
+        : sanitizedUri.toString();
   }
 
   dynamic _sanitizeBody(dynamic data) {
@@ -288,8 +342,12 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   void _log(Iterable<String> lines) {
-    if (_logger == null) return;
-    lines.forEach(_logger.logInfo);
+    final logger = _logger;
+    if (logger == null) return;
+    // ignore: prefer_foreach, Performance: Use for-in to avoid closure allocation.
+    for (final line in lines) {
+      logger.logInfo(line);
+    }
   }
 
   void _logError(Iterable<String> lines, {StackTrace? stackTrace}) {

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
@@ -464,5 +464,118 @@ void main() {
         returnsNormally,
       );
     });
+
+    test('onRequest should redact userInfo password in URI', () {
+      final options = RequestOptions(
+        path: 'https://user:password123@api.example.com/data',
+        method: 'GET',
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(
+            that: allOf(
+              contains('URI: https://user:***REDACTED***@api.example.com/data'),
+            ),
+          ),
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('password123')),
+        ),
+      );
+    });
+
+    test('onRequest should redact sensitive keys in URI fragment', () {
+      final options = RequestOptions(
+        path: 'https://api.example.com/auth#access_token=secret&state=123',
+        method: 'GET',
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(
+            that: allOf(
+              contains('access_token=***REDACTED***'),
+              contains('state=123'),
+            ),
+          ),
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('secret')),
+        ),
+      );
+    });
+
+    test('onRequest should redact new default sensitive headers', () {
+      final options = RequestOptions(
+        path: 'https://api.example.com',
+        method: 'GET',
+        headers: {
+          'authentication': 'Bearer token',
+          'x-auth-token': 'auth-token',
+          'xsrf-token': 'xsrf',
+          'csrf-token': 'csrf',
+          'session-id': 'session',
+          'sid': 'sid-value',
+        },
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('***REDACTED***')),
+        ),
+      ).called(6);
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(
+            that: anyOf([
+              contains('Bearer token'),
+              contains('auth-token'),
+              contains('xsrf'),
+              contains('csrf'),
+              contains('session'),
+              contains('sid-value'),
+            ]),
+          ),
+        ),
+      );
+    });
+
+    test('onRequest should redact new default sensitive query params', () {
+      final options = RequestOptions(
+        path:
+            'https://api.example.com?session_id=s123&sid=s456&csrf_token=c789&xsrf_token=x012',
+        method: 'GET',
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(
+            that: allOf(
+              contains('session_id=%2A%2A%2AREDACTED%2A%2A%2A'),
+              contains('sid=%2A%2A%2AREDACTED%2A%2A%2A'),
+              contains('csrf_token=%2A%2A%2AREDACTED%2A%2A%2A'),
+              contains('xsrf_token=%2A%2A%2AREDACTED%2A%2A%2A'),
+            ),
+          ),
+        ),
+      ).called(1);
+    });
   });
 }


### PR DESCRIPTION
### Summary
This PR significantly strengthens the security of the `fluent_networking` toolkit by expanding its sensitive data redaction capabilities within network logs.

### Key Changes
- **Credential Protection in URIs:** The logging interceptor now automatically identifies and redacts passwords embedded in URIs (e.g., `https://user:password@host`).
- **URI Fragment Redaction:** Enhanced the sanitization logic to parse URI fragments and redact sensitive keys (like `access_token`), which are frequently used in OAuth2 and other authentication flows.
- **Comprehensive Security Defaults:** Expanded the default redaction lists for headers, query parameters, and body keys to include common security-sensitive fields such as `session_id`, `csrf-token`, `x-auth-token`, and more.
- **Performance Optimization:** Refactored the internal logging loops to improve efficiency and reduce memory overhead during high-frequency networking operations.
- **Verification:** Added a robust suite of new unit tests to ensure all redaction scenarios are correctly handled and verified against regressions.

These enhancements ensure that developers using the Fluent toolkit are less likely to accidentally leak sensitive user information or authentication credentials into their application logs.

---
*PR created automatically by Jules for task [12181223648381349642](https://jules.google.com/task/12181223648381349642) started by @aosorio-avilez*