### PR TITLE
feat(environment): add feature flags capability and inspector integration

### DIFF
--- a/packages/fluent_environment/fluent_environment/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 0.8.1
+## 0.9.0
 
+* FEAT: Integrated Feature Flags support in `EnvironmentInspector` with interactive toggles.
+* FEAT: Implemented runtime feature flag overrides in `EnvironmentApiImpl`.
+* FEAT: Updated `example` to demonstrate feature flag usage and reactivity.
 * FEAT: Added standard Close button (`IconButton` with cross icon) to `EnvironmentInspector`.
 * FEAT: Added accessibility semantics (`onLongPressHint`, labels, and `Sensitive configuration value` semantics) to both `EnvironmentBanner` and `EnvironmentInspector`.
 * FEAT: Colored sensitive configurations with the theme's error color in the inspector.

--- a/packages/fluent_environment/fluent_environment/README.md
+++ b/packages/fluent_environment/fluent_environment/README.md
@@ -6,7 +6,7 @@ Package that provides a way to register your environment and display it
 ### Add dependencies
 
 ```yaml
-fluent_environment: ^0.8.0
+fluent_environment: ^0.9.0
 ```
 
 ### Define environment
@@ -19,6 +19,11 @@ class DevEnvironment extends Environment {
     Color get color => Colors.blue;
     @override
     EnvironmentType get type => EnvironmentType.dev;
+    @override
+    Map<String, bool> get features => {
+        'new_payment_flow': true,
+        'beta_features': false,
+    };
 }
 
 class ProdEnvironment extends Environment {
@@ -98,7 +103,30 @@ class MainApp extends StatelessWidget {
 The inspector allows you to:
 1. **Switch Environments**: Instantly change the current environment.
 2. **View Config**: Inspect the current environment's configuration values.
-3. **Reactive UI**: The UI and reconstructed services will update automatically.
+3. **Toggle Feature Flags**: Instantly toggle any environment features at runtime.
+4. **Reactive UI**: The UI, feature flag overrides, and reconstructed services will update automatically.
+
+## Feature Flags
+
+Define a map of feature flags for each environment to check their status and override them at runtime within the inspector.
+
+### 1. Check Feature Status
+
+```dart
+final api = Fluent.get<EnvironmentApi>();
+
+// Check if a feature is enabled
+final isEnabled = api.isFeatureEnabled('new_payment_flow');
+```
+
+### 2. Override at Runtime
+
+```dart
+// Override the feature flag value at runtime
+api.setFeatureFlag('new_payment_flow', value: false);
+```
+
+Whenever a feature flag is overridden, the `environmentNotifier` will automatically trigger notifications so that your UI reactively rebuilds with the new state.
 
 ## Example
 

--- a/packages/fluent_environment/fluent_environment/example/lib/app_environment.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/app_environment.dart
@@ -16,6 +16,9 @@ class DevEnvironment extends Environment {
   };
 
   @override
+  Map<String, bool> get features => {'search_v2': true, 'payment_v2': false};
+
+  @override
   EnvironmentType get type => EnvironmentType.dev;
 }
 
@@ -34,6 +37,9 @@ class StagingEnvironment extends Environment {
   };
 
   @override
+  Map<String, bool> get features => {'search_v2': true, 'payment_v2': false};
+
+  @override
   EnvironmentType get type => EnvironmentType.stg;
 }
 
@@ -50,6 +56,9 @@ class ProdEnvironment extends Environment {
     'api_key': 'prod-key-789',
     'debug_mode': 'false',
   };
+
+  @override
+  Map<String, bool> get features => {'search_v2': false, 'payment_v2': false};
 
   @override
   EnvironmentType get type => EnvironmentType.prod;

--- a/packages/fluent_environment/fluent_environment/example/lib/main.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/main.dart
@@ -54,7 +54,31 @@ class HomePage extends StatelessWidget {
             ValueListenableBuilder<Environment>(
               valueListenable: Fluent.get<EnvironmentApi>().environmentNotifier,
               builder: (context, environment, _) {
-                return Text("Current Environment: ${environment.name}");
+                final api = Fluent.get<EnvironmentApi>();
+                final isSearchV2 = api.isFeatureEnabled('search_v2');
+                final isPaymentV2 = api.isFeatureEnabled('payment_v2');
+
+                return Column(
+                  children: [
+                    Text("Current Environment: ${environment.name}"),
+                    const SizedBox(height: 16),
+                    Text(
+                      "Search V2 Feature: ${isSearchV2 ? 'ENABLED' : 'DISABLED'}",
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: isSearchV2 ? Colors.green : Colors.red,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      "Payment V2 Feature: ${isPaymentV2 ? 'ENABLED' : 'DISABLED'}",
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: isPaymentV2 ? Colors.green : Colors.red,
+                      ),
+                    ),
+                  ],
+                );
               },
             ),
             const SizedBox(height: 16),

--- a/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
@@ -9,11 +9,12 @@ class EnvironmentApiImpl extends EnvironmentApi {
     Environment environment,
     this.availableEnvironments,
     this.registry,
-  ) : _environmentNotifier = ValueNotifier(environment);
+  ) : _environmentNotifier = _EnvironmentNotifier(environment);
 
-  final ValueNotifier<Environment> _environmentNotifier;
+  final _EnvironmentNotifier _environmentNotifier;
   final Registry registry;
   final List<void Function()> _resetters = [];
+  final Map<String, bool> _featureOverrides = {};
 
   @override
   final List<Environment> availableEnvironments;
@@ -26,6 +27,7 @@ class EnvironmentApiImpl extends EnvironmentApi {
 
   @override
   void updateEnvironment(Environment environment) {
+    _featureOverrides.clear();
     _environmentNotifier.value = environment;
     for (final reset in _resetters) {
       reset();
@@ -35,6 +37,17 @@ class EnvironmentApiImpl extends EnvironmentApi {
   @override
   void registerResetService<T extends Object>() {
     _resetters.add(() => registry.resetLazySingleton<T>());
+  }
+
+  @override
+  bool isFeatureEnabled(String key) {
+    return _featureOverrides[key] ?? environment.features[key] ?? false;
+  }
+
+  @override
+  void setFeatureFlag(String key, {required bool value}) {
+    _featureOverrides[key] = value;
+    _environmentNotifier.refresh();
   }
 
   @override
@@ -59,4 +72,10 @@ class EnvironmentApiImpl extends EnvironmentApi {
       },
     );
   }
+}
+
+class _EnvironmentNotifier extends ValueNotifier<Environment> {
+  _EnvironmentNotifier(super._value);
+
+  void refresh() => notifyListeners();
 }

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -128,6 +128,40 @@ class EnvironmentInspector extends StatelessWidget {
                     ),
                     const Divider(height: 24),
                   ],
+                  if (environment.features.isNotEmpty) ...[
+                    Text(
+                      'Features',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    ListView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: environment.features.length,
+                      itemBuilder: (context, index) {
+                        final key = environment.features.keys.elementAt(index);
+                        final isEnabled = environmentApi.isFeatureEnabled(key);
+
+                        return SwitchListTile(
+                          title: Text(
+                            key,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          value: isEnabled,
+                          onChanged: (value) {
+                            environmentApi.setFeatureFlag(key, value: value);
+                          },
+                          contentPadding: EdgeInsets.zero,
+                          dense: true,
+                        );
+                      },
+                    ),
+                    const Divider(height: 24),
+                  ],
                   Text(
                     configValuesLabel,
                     style: theme.textTheme.titleMedium?.copyWith(

--- a/packages/fluent_environment/fluent_environment/pubspec.yaml
+++ b/packages/fluent_environment/fluent_environment/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_environment
 description: Package that provides a way to register your environment globally and display it.
-version: 0.8.1
+version: 0.9.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_environment/fluent_environment
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   fluent_sdk: ^0.8.0
-  fluent_environment_api: ^0.5.0
+  fluent_environment_api: ^0.6.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -84,6 +84,7 @@ void main() {
       when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
       when(() => mockEnv.color).thenReturn(Colors.red);
       when(() => mockEnv.values).thenReturn({});
+      when(() => mockEnv.features).thenReturn({});
       when(() => mockEnv.sensitiveKeys).thenReturn({});
 
       final mockRegistry = MockRegistry();
@@ -119,6 +120,7 @@ void main() {
     when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
     when(() => mockEnv.color).thenReturn(Colors.red);
     when(() => mockEnv.values).thenReturn({});
+    when(() => mockEnv.features).thenReturn({});
     when(() => mockEnv.sensitiveKeys).thenReturn({});
 
     final navigatorKey = GlobalKey<NavigatorState>();
@@ -144,5 +146,68 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     expect(find.byType(EnvironmentInspector), findsOneWidget);
+  });
+
+  group('Feature Flags', () {
+    test('isFeatureEnabled returns value from environment if no override', () {
+      final mockEnv = MockEnvironment();
+      when(() => mockEnv.features).thenReturn({
+        'feature1': true,
+        'feature2': false,
+      });
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
+
+      expect(api.isFeatureEnabled('feature1'), isTrue);
+      expect(api.isFeatureEnabled('feature2'), isFalse);
+      expect(api.isFeatureEnabled('unknown'), isFalse);
+    });
+
+    test('isFeatureEnabled returns value from override if present', () {
+      final mockEnv = MockEnvironment();
+      when(() => mockEnv.features).thenReturn({'feature1': true});
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry)
+        ..setFeatureFlag('feature1', value: false)
+        ..setFeatureFlag('feature2', value: true);
+
+      expect(api.isFeatureEnabled('feature1'), isFalse);
+      expect(api.isFeatureEnabled('feature2'), isTrue);
+    });
+
+    test('setFeatureFlag notifies listeners', () {
+      final mockEnv = MockEnvironment();
+      when(() => mockEnv.features).thenReturn({});
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
+      var notified = false;
+
+      api.environmentNotifier.addListener(() {
+        notified = true;
+      });
+
+      api.setFeatureFlag('feature1', value: true);
+
+      expect(notified, isTrue);
+    });
+
+    test('updateEnvironment clears feature overrides', () {
+      final mockEnv1 = MockEnvironment();
+      final mockEnv2 = MockEnvironment();
+      when(() => mockEnv1.features).thenReturn({'feature1': true});
+      when(() => mockEnv2.features).thenReturn({'feature1': true});
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(
+        mockEnv1,
+        [mockEnv1, mockEnv2],
+        mockRegistry,
+      )..setFeatureFlag('feature1', value: false);
+
+      expect(api.isFeatureEnabled('feature1'), isFalse);
+
+      api.updateEnvironment(mockEnv2);
+
+      expect(api.isFeatureEnabled('feature1'), isTrue);
+    });
   });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -19,6 +19,7 @@ void main() {
     mockEnv = MockEnvironment();
     mockApi = MockEnvironmentApi();
     when(() => mockEnv.sensitiveKeys).thenReturn({});
+    when(() => mockEnv.features).thenReturn({});
     when(() => mockEnv.name).thenReturn('Development');
     when(() => mockEnv.type).thenReturn(EnvironmentType.dev);
     when(() => mockEnv.color).thenReturn(Colors.blue);
@@ -78,6 +79,7 @@ void main() {
     when(() => mockEnv2.type).thenReturn(EnvironmentType.stg);
     when(() => mockEnv2.color).thenReturn(Colors.orange);
     when(() => mockEnv2.values).thenReturn({});
+    when(() => mockEnv2.features).thenReturn({});
     when(() => mockEnv2.sensitiveKeys).thenReturn({});
 
     when(() => mockApi.availableEnvironments).thenReturn([mockEnv, mockEnv2]);
@@ -192,5 +194,57 @@ void main() {
     final tooltip = tester.widget<IconButton>(copyIconButton).tooltip;
     expect(tooltip, contains('public_key'));
     expect(tooltip, isNot(contains('secret_key')));
+  });
+
+  testWidgets('should display and toggle feature flags', (tester) async {
+    // Arrange
+    when(() => mockEnv.features).thenReturn({
+      'feature1': true,
+      'feature2': false,
+    });
+    when(() => mockApi.isFeatureEnabled('feature1')).thenReturn(true);
+    when(() => mockApi.isFeatureEnabled('feature2')).thenReturn(false);
+    when(
+      () => mockApi.setFeatureFlag(
+        any(),
+        value: any(named: 'value'),
+      ),
+    ).thenReturn(null);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EnvironmentInspector(environmentApi: mockApi),
+        ),
+      ),
+    );
+
+    // Assert
+    expect(find.text('Features'), findsOneWidget);
+    expect(find.text('feature1'), findsOneWidget);
+    expect(find.text('feature2'), findsOneWidget);
+
+    final switch1 = tester.widget<Switch>(
+      find.descendant(
+        of: find.widgetWithText(SwitchListTile, 'feature1'),
+        matching: find.byType(Switch),
+      ),
+    );
+    expect(switch1.value, isTrue);
+
+    final switch2 = tester.widget<Switch>(
+      find.descendant(
+        of: find.widgetWithText(SwitchListTile, 'feature2'),
+        matching: find.byType(Switch),
+      ),
+    );
+    expect(switch2.value, isFalse);
+
+    // Act
+    await tester.tap(find.text('feature1'));
+    await tester.pump();
+
+    // Assert
+    verify(() => mockApi.setFeatureFlag('feature1', value: false)).called(1);
   });
 }

--- a/packages/fluent_environment/fluent_environment_api/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+* FEAT: Added Feature Flags capability to `Environment` and `EnvironmentApi`.
+* FEAT: Added `isFeatureEnabled` and `setFeatureFlag` to `EnvironmentApi`.
+
 ## 0.5.0
 
 * FEAT: Added `environmentNotifier` (ValueListenable) to `EnvironmentApi` for reactive UI updates.

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment.dart
@@ -18,6 +18,9 @@ abstract class Environment {
   /// A map of configuration values (API Keys, Base URLs, etc.).
   Map<String, String> get values;
 
+  /// A map of feature flags.
+  Map<String, bool> get features => const {};
+
   /// A set of keys that should be redacted in logs or UI.
   Set<String> get sensitiveKeys => const {};
 }

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
@@ -31,4 +31,10 @@ abstract class EnvironmentApi {
     String? noValuesLabel,
     GlobalKey<NavigatorState>? navigatorKey,
   });
+
+  /// Checks if a feature is enabled.
+  bool isFeatureEnabled(String key);
+
+  /// Sets a feature flag value at runtime.
+  void setFeatureFlag(String key, {required bool value});
 }

--- a/packages/fluent_environment/fluent_environment_api/pubspec.yaml
+++ b/packages/fluent_environment/fluent_environment_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_environment_api
 description: A common interface for the fluent_environment package.
-version: 0.5.0
+version: 0.6.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_environment/fluent_environment_api
 


### PR DESCRIPTION
## Description
This PR introduces a new **Feature Flags** capability to the `fluent_environment` package. This allows developers to manage and toggle application features at runtime, which is essential for controlled rollouts, experiments, and testing.

### Key Changes:
- **API Contract**: Updated `Environment` to include a `features` map and `EnvironmentApi` with `isFeatureEnabled` and `setFeatureFlag` methods.
- **Runtime Overrides**: `EnvironmentApiImpl` now supports in-memory feature flag overrides that persist across the session but are reset when the environment is switched.
- **Environment Inspector**: Added a new "Features" section to the inspector bottom sheet, featuring interactive switches to toggle flags at runtime.
- **Reactive UI**: Integrated with the toolkit's reactive system to ensure the UI updates immediately when a feature flag is changed.
- **Tests**: Added comprehensive unit and widget tests for the new functionality.
- **Example App**: Enhanced the example application to demonstrate how to define feature flags and use them in a reactive widget.

### Why this is valuable:
Feature flags are a staple in modern mobile development. By integrating them directly into the Fluent toolkit, developers can now easily manage feature visibility and behavior without additional external dependencies, directly from the built-in developer menu.

---
*PR created automatically by Jules for task [10911937250976381569](https://jules.google.com/task/10911937250976381569) started by @aosorio-avilez*