### PR TITLE
perf(networking): optimize networking log interceptor

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -178,13 +178,15 @@ class NetworkingLogInterceptor extends Interceptor {
     yield '└──────────────────────────────────────────────────────────────────';
   }
 
-  Iterable<String> _formatHeaders(Map<String, dynamic> headers) {
-    return headers.entries.map((entry) {
+  Iterable<String> _formatHeaders(Map<String, dynamic> headers) sync* {
+    for (final entry in headers.entries) {
       final key = entry.key;
-      final isSensitive = _sensitiveHeaders.contains(key.toLowerCase());
+      final isSensitive =
+          _sensitiveHeaders.contains(key) ||
+          _sensitiveHeaders.contains(key.toLowerCase());
       final value = isSensitive ? '***REDACTED***' : entry.value.toString();
-      return '$key: $value';
-    });
+      yield '$key: $value';
+    }
   }
 
   String _formatData(dynamic data) {
@@ -202,19 +204,19 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   String _sanitizeUri(Uri uri) {
-    if (uri.queryParameters.isEmpty) return uri.toString();
+    final queryParametersAll = uri.queryParametersAll;
+    if (queryParametersAll.isEmpty) return uri.toString();
 
     Map<String, dynamic>? queryParameters;
 
-    for (final key in uri.queryParametersAll.keys) {
+    for (final entry in queryParametersAll.entries) {
+      final key = entry.key;
       final isSensitive =
           _sensitiveQueryParams.contains(key) ||
           _sensitiveQueryParams.contains(key.toLowerCase());
 
       if (isSensitive) {
-        queryParameters ??= Map<String, List<String>>.of(
-          uri.queryParametersAll,
-        );
+        queryParameters ??= Map<String, List<String>>.of(queryParametersAll);
         queryParameters[key] = ['***REDACTED***'];
       }
     }
@@ -289,7 +291,10 @@ class NetworkingLogInterceptor extends Interceptor {
 
   void _log(Iterable<String> lines) {
     if (_logger == null) return;
-    lines.forEach(_logger.logInfo);
+    // ignore: prefer_foreach, Performance: avoiding closure allocation in loop
+    for (final line in lines) {
+      _logger.logInfo(line);
+    }
   }
 
   void _logError(Iterable<String> lines, {StackTrace? stackTrace}) {


### PR DESCRIPTION
## Description
This PR introduces several micro-optimizations to the `NetworkingLogInterceptor` in the `fluent_networking` package to improve performance and reduce memory allocations during network logging.

Key improvements:
- **Reduced Allocation:** Refactored `_formatHeaders` to use a `sync*` generator and a `for-in` loop instead of `.map()`, avoiding closure allocation and `MappedIterable` overhead.
- **Efficient Loop:** Updated the `_log` method to use a standard `for-in` loop instead of `forEach` with a method tear-off, eliminating closure overhead in the logging hot path.
- **Optimized URI Sanitization:** Improved `_sanitizeUri` by caching `uri.queryParametersAll` and iterating over its entries once, reducing redundant property access and map lookups.
- **Faster Sensitive Lookups:** Improved sensitive key lookup efficiency in `_formatHeaders` and `_sanitizeUri` by checking for direct matches in the sensitive keys set before falling back to a case-insensitive check, minimizing unnecessary `toLowerCase()` calls.

These changes ensure that the core networking toolkit remains lightweight and efficient, providing a faster experience for all consuming applications.

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash


---
*PR created automatically by Jules for task [1138949160245067608](https://jules.google.com/task/1138949160245067608) started by @aosorio-avilez*