### PR TITLE
fix(networking): redact sensitive information in URI userInfo and fragments

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -202,26 +202,68 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   String _sanitizeUri(Uri uri) {
-    if (uri.queryParameters.isEmpty) return uri.toString();
+    var sanitizedUri = uri;
 
-    Map<String, dynamic>? queryParameters;
+    // Sanitize userInfo (redact password)
+    if (uri.userInfo.contains(':')) {
+      final parts = uri.userInfo.split(':');
+      final username = parts[0];
+      sanitizedUri = sanitizedUri.replace(userInfo: '$username:***REDACTED***');
+    }
 
-    for (final key in uri.queryParametersAll.keys) {
-      final isSensitive =
-          _sensitiveQueryParams.contains(key) ||
-          _sensitiveQueryParams.contains(key.toLowerCase());
+    // Sanitize query parameters
+    if (uri.queryParameters.isNotEmpty) {
+      Map<String, List<String>>? queryParameters;
 
-      if (isSensitive) {
-        queryParameters ??= Map<String, List<String>>.of(
-          uri.queryParametersAll,
-        );
-        queryParameters[key] = ['***REDACTED***'];
+      for (final key in uri.queryParametersAll.keys) {
+        final isSensitive =
+            _sensitiveQueryParams.contains(key) ||
+            _sensitiveQueryParams.contains(key.toLowerCase());
+
+        if (isSensitive) {
+          queryParameters ??= Map<String, List<String>>.of(
+            uri.queryParametersAll,
+          );
+          queryParameters[key] = ['***REDACTED***'];
+        }
+      }
+
+      if (queryParameters != null) {
+        sanitizedUri = sanitizedUri.replace(queryParameters: queryParameters);
       }
     }
 
-    return queryParameters != null
-        ? uri.replace(queryParameters: queryParameters).toString()
-        : uri.toString();
+    // Sanitize fragment
+    if (uri.hasFragment) {
+      final fragment = uri.fragment;
+      if (fragment.contains('=') || fragment.contains('&')) {
+        final fragmentParams = Uri.splitQueryString(fragment);
+        var fragmentChanged = false;
+        final sanitizedFragmentParams = <String, String>{};
+
+        for (final entry in fragmentParams.entries) {
+          final isSensitive =
+              _sensitiveQueryParams.contains(entry.key) ||
+              _sensitiveQueryParams.contains(entry.key.toLowerCase());
+
+          if (isSensitive) {
+            sanitizedFragmentParams[entry.key] = '***REDACTED***';
+            fragmentChanged = true;
+          } else {
+            sanitizedFragmentParams[entry.key] = entry.value;
+          }
+        }
+
+        if (fragmentChanged) {
+          final newFragment = sanitizedFragmentParams.entries
+              .map((e) => '${e.key}=${e.value}')
+              .join('&');
+          sanitizedUri = sanitizedUri.replace(fragment: newFragment);
+        }
+      }
+    }
+
+    return sanitizedUri.toString();
   }
 
   dynamic _sanitizeBody(dynamic data) {

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/uri_security_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/uri_security_test.dart
@@ -1,0 +1,57 @@
+import 'package:dio/dio.dart';
+import 'package:fluent_logger_api/fluent_logger_api.dart';
+import 'package:fluent_networking/src/interceptors/networking_log_interceptor.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockLoggerApi extends Mock implements LoggerApi {}
+
+void main() {
+  test('NetworkingLogInterceptor should redact password in URI userInfo', () {
+    final mockLoggerApi = MockLoggerApi();
+    final interceptor = NetworkingLogInterceptor(logger: mockLoggerApi);
+    final options = RequestOptions(
+      path: 'https://user:password@api.example.com/path',
+    );
+
+    interceptor.onRequest(options, MockRequestInterceptorHandler());
+
+    verify(
+      () => mockLoggerApi.logInfo(
+        any<String>(
+          that: contains('https://user:***REDACTED***@api.example.com/path'),
+        ),
+      ),
+    ).called(1);
+    verifyNever(
+      () => mockLoggerApi.logInfo(any<String>(that: contains('password'))),
+    );
+  });
+
+  test(
+    'NetworkingLogInterceptor should redact sensitive keys in URI fragment',
+    () {
+      final mockLoggerApi = MockLoggerApi();
+      final interceptor = NetworkingLogInterceptor(logger: mockLoggerApi);
+      final options = RequestOptions(
+        path:
+            'https://api.example.com/path#access_token=secret_token&other=value',
+      );
+
+      interceptor.onRequest(options, MockRequestInterceptorHandler());
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('access_token=***REDACTED***')),
+        ),
+      ).called(1);
+      verifyNever(
+        () =>
+            mockLoggerApi.logInfo(any<String>(that: contains('secret_token'))),
+      );
+    },
+  );
+}
+
+class MockRequestInterceptorHandler extends Mock
+    implements RequestInterceptorHandler {}


### PR DESCRIPTION
Enhanced NetworkingLogInterceptor to redact passwords in URI userInfo and sensitive keys in URI fragments to prevent credential leakage in logs. Added unit tests to verify the fix.

---
*PR created automatically by Jules for task [6688140070629071008](https://jules.google.com/task/6688140070629071008) started by @aosorio-avilez*