### PR TITLE
perf(networking): optimize option merging and error mapping in networking api

### DIFF
--- a/packages/fluent_networking/fluent_networking/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.2
+
+* PERF: Optimized `NetworkingApiImpl` to avoid redundant map allocations during option merging.
+* PERF: Reduced map lookups in Dio error mapping for better efficiency.
+* PERF: Optimized `NetworkingLogInterceptor` data formatting and URI sanitization to skip redundant processing and use faster property checks.
+
 ## 0.9.1
 
 * PERF: Optimized `NetworkingLogInterceptor` header formatting to use a lazy `sync*` generator and avoided closure allocation overhead in the logging path.

--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -195,11 +195,11 @@ class NetworkingLogInterceptor extends Interceptor {
 
   String _formatData(dynamic data) {
     try {
-      final sanitized = _sanitizeBody(data);
-      if (sanitized is String) {
-        final decoded = json.decode(sanitized);
+      if (data is String) {
+        final decoded = json.decode(data);
         return _encoder.convert(_sanitizeBody(decoded));
       }
+      final sanitized = _sanitizeBody(data);
       return _encoder.convert(sanitized);
     } on Object catch (_) {
       // Return raw data if it fails to format as JSON
@@ -208,7 +208,7 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   String _sanitizeUri(Uri uri) {
-    if (uri.queryParameters.isEmpty) return uri.toString();
+    if (!uri.hasQuery) return uri.toString();
 
     Map<String, dynamic>? queryParameters;
     final queryParametersAll = uri.queryParametersAll;

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_api_impl.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_api_impl.dart
@@ -99,7 +99,9 @@ class NetworkingApiImpl extends NetworkingApi {
     if (retryConfig == null && cacheConfig == null) return options ?? Options();
 
     final effectiveOptions = options ?? Options();
-    final extra = Map<String, dynamic>.from(effectiveOptions.extra ?? {});
+    final extra = effectiveOptions.extra != null
+        ? Map<String, dynamic>.from(effectiveOptions.extra!)
+        : <String, dynamic>{};
 
     if (retryConfig != null) {
       extra[NetworkingRetryInterceptor.extraRetryConfig] = retryConfig;
@@ -134,8 +136,11 @@ class NetworkingApiImpl extends NetworkingApi {
     var msg = e.message ?? 'Unknown network error';
     final dynamic errorData = e.response?.data;
 
-    if (errorData is Map && errorData.containsKey('message')) {
-      msg = errorData['message'].toString();
+    if (errorData is Map) {
+      final message = errorData['message'];
+      if (message != null) {
+        msg = message.toString();
+      }
     }
 
     return HttpError(

--- a/packages/fluent_networking/fluent_networking/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_networking
 description: Package that provides a simple way to make http requests
-version: 0.9.1
+version: 0.9.2
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_networking/fluent_networking
 


### PR DESCRIPTION
This PR introduces several micro-optimizations to the `fluent_networking` package to enhance its execution speed and memory efficiency. These changes focus on reducing redundant map allocations, minimizing dictionary lookups, and streamlining data processing in the core networking implementation and its logging interceptor.

Key improvements:
- **`NetworkingApiImpl`**: Optimized `_mergeOptions` to skip unnecessary map copies when no extra configuration is present and improved `_mapDioError` to use a single lookup for error messages.
- **`NetworkingLogInterceptor`**: Optimized `_formatData` to eliminate redundant sanitization passes for raw strings and switched `_sanitizeUri` to use a more efficient query presence check.

These enhancements ensure that the networking layer remains lightweight and performant, which is critical as it serves as a foundational component for all applications built using the `flutter_fluent` toolkit.

---
*PR created automatically by Jules for task [15302109896521793659](https://jules.google.com/task/15302109896521793659) started by @aosorio-avilez*