### PR TITLE
fix(networking): integrate environment sensitive keys with log interceptor

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import 'package:fluent_environment_api/fluent_environment_api.dart';
 import 'package:fluent_logger_api/fluent_logger_api.dart';
 
 /// A secure networking interceptor that logs requests and responses.
@@ -11,10 +12,12 @@ class NetworkingLogInterceptor extends Interceptor {
   /// Creates a [NetworkingLogInterceptor].
   NetworkingLogInterceptor({
     required LoggerApi? logger,
+    EnvironmentApi? environmentApi,
     Set<String>? sensitiveHeaders,
     Set<String>? sensitiveBodyKeys,
     Set<String>? sensitiveQueryParams,
   }) : _logger = logger,
+       _environmentApi = environmentApi,
        _sensitiveHeaders = {
          ..._defaultSensitiveHeaders,
          if (sensitiveHeaders != null)
@@ -32,6 +35,7 @@ class NetworkingLogInterceptor extends Interceptor {
        };
 
   final LoggerApi? _logger;
+  final EnvironmentApi? _environmentApi;
   final Set<String> _sensitiveHeaders;
   final Set<String> _sensitiveBodyKeys;
   final Set<String> _sensitiveQueryParams;
@@ -183,11 +187,15 @@ class NetworkingLogInterceptor extends Interceptor {
   /// Note: [headers] can be `Map<String, dynamic>` (from requests) or
   /// `Map<String, List<String>>` (from response/error).
   Iterable<String> _formatHeaders(Map<String, dynamic> headers) sync* {
+    final envSensitiveKeys = _environmentApi?.environment.sensitiveKeys;
+
     for (final entry in headers.entries) {
       final key = entry.key;
-      final isSensitive =
-          _sensitiveHeaders.contains(key) ||
-          _sensitiveHeaders.contains(key.toLowerCase());
+      final lowerKey = key.toLowerCase();
+      final isSensitive = _sensitiveHeaders.contains(key) ||
+          _sensitiveHeaders.contains(lowerKey) ||
+          (envSensitiveKeys?.contains(key) ?? false) ||
+          (envSensitiveKeys?.contains(lowerKey) ?? false);
       final value = isSensitive ? '***REDACTED***' : entry.value.toString();
       yield '$key: $value';
     }
@@ -212,11 +220,14 @@ class NetworkingLogInterceptor extends Interceptor {
 
     Map<String, dynamic>? queryParameters;
     final queryParametersAll = uri.queryParametersAll;
+    final envSensitiveKeys = _environmentApi?.environment.sensitiveKeys;
 
     for (final key in queryParametersAll.keys) {
-      final isSensitive =
-          _sensitiveQueryParams.contains(key) ||
-          _sensitiveQueryParams.contains(key.toLowerCase());
+      final lowerKey = key.toLowerCase();
+      final isSensitive = _sensitiveQueryParams.contains(key) ||
+          _sensitiveQueryParams.contains(lowerKey) ||
+          (envSensitiveKeys?.contains(key) ?? false) ||
+          (envSensitiveKeys?.contains(lowerKey) ?? false);
 
       if (isSensitive) {
         queryParameters ??= Map<String, List<String>>.of(
@@ -232,15 +243,22 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   dynamic _sanitizeBody(dynamic data) {
-    if (_sensitiveBodyKeys.isEmpty) return data;
+    final envSensitiveKeys = _environmentApi?.environment.sensitiveKeys;
+
+    if (_sensitiveBodyKeys.isEmpty && (envSensitiveKeys?.isEmpty ?? true)) {
+      return data;
+    }
 
     if (data is FormData) {
       final fields = <String, dynamic>{};
       for (final entry in data.fields) {
-        final isSensitive =
-            _sensitiveBodyKeys.contains(entry.key) ||
-            _sensitiveBodyKeys.contains(entry.key.toLowerCase());
-        fields[entry.key] = isSensitive ? '***REDACTED***' : entry.value;
+        final key = entry.key;
+        final lowerKey = key.toLowerCase();
+        final isSensitive = _sensitiveBodyKeys.contains(key) ||
+            _sensitiveBodyKeys.contains(lowerKey) ||
+            (envSensitiveKeys?.contains(key) ?? false) ||
+            (envSensitiveKeys?.contains(lowerKey) ?? false);
+        fields[key] = isSensitive ? '***REDACTED***' : entry.value;
       }
       for (final entry in data.files) {
         fields[entry.key] = '[FILE: ${entry.value.filename}]';
@@ -252,11 +270,15 @@ class NetworkingLogInterceptor extends Interceptor {
       for (final entry in data.entries) {
         final key = entry.key;
         final value = entry.value;
+        final stringKey = key.toString();
+        final lowerKey = stringKey.toLowerCase();
 
         // Optimized sensitive key check: direct match first, then normalized
         final isSensitive =
             (key is String && _sensitiveBodyKeys.contains(key)) ||
-            _sensitiveBodyKeys.contains(key.toString().toLowerCase());
+            _sensitiveBodyKeys.contains(lowerKey) ||
+            (envSensitiveKeys?.contains(stringKey) ?? false) ||
+            (envSensitiveKeys?.contains(lowerKey) ?? false);
 
         if (isSensitive) {
           result ??= Map<dynamic, dynamic>.of(data);

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_module.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:fluent_environment_api/fluent_environment_api.dart';
 import 'package:fluent_logger_api/fluent_logger_api.dart';
 import 'package:fluent_networking/fluent_networking.dart';
 import 'package:fluent_networking/src/interceptors/networking_cache_interceptor.dart';
@@ -32,9 +33,13 @@ class NetworkingModule extends FluentModule {
         if (config.enableLog &&
             !const bool.fromEnvironment('dart.vm.product')) {
           final logger = it.isRegistered<LoggerApi>() ? it<LoggerApi>() : null;
+          final environmentApi =
+              it.isRegistered<EnvironmentApi>() ? it<EnvironmentApi>() : null;
+
           dio.interceptors.add(
             NetworkingLogInterceptor(
               logger: logger,
+              environmentApi: environmentApi,
               sensitiveHeaders: config.sensitiveHeaders,
               sensitiveBodyKeys: config.sensitiveBodyKeys,
               sensitiveQueryParams: config.sensitiveQueryParams,

--- a/packages/fluent_networking/fluent_networking/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   fluent_sdk: ^0.8.0
   fluent_networking_api: ^0.4.0
   fluent_logger_api: ^0.0.4
+  fluent_environment_api: ^0.6.0
   dio: ^5.9.1
   equatable: ^2.0.8
 

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:fluent_environment_api/fluent_environment_api.dart';
 import 'package:fluent_logger_api/fluent_logger_api.dart';
 import 'package:fluent_networking/src/interceptors/networking_log_interceptor.dart';
 import 'package:fluent_sdk/fluent_sdk.dart';
@@ -6,6 +7,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 class MockLoggerApi extends Mock implements LoggerApi {}
+
+class MockEnvironmentApi extends Mock implements EnvironmentApi {}
+
+class MockEnvironment extends Mock implements Environment {}
 
 class MockRequestInterceptorHandler extends Mock
     implements RequestInterceptorHandler {}
@@ -462,6 +467,51 @@ void main() {
       expect(
         () => noLoggerInterceptor.onRequest(options, handler),
         returnsNormally,
+      );
+    });
+
+    test('onRequest should redact sensitive keys from Environment', () {
+      final mockEnvironmentApi = MockEnvironmentApi();
+      final mockEnvironment = MockEnvironment();
+      when(() => mockEnvironmentApi.environment).thenReturn(mockEnvironment);
+      when(() => mockEnvironment.sensitiveKeys).thenReturn({'env_secret'});
+
+      final customInterceptor = NetworkingLogInterceptor(
+        logger: mockLoggerApi,
+        environmentApi: mockEnvironmentApi,
+      );
+
+      final options = RequestOptions(
+        path: 'https://api.example.com?env_secret=value',
+        method: 'POST',
+        headers: {'env_secret': 'header-value'},
+        data: {'env_secret': 'body-value'},
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      customInterceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('env_secret=%2A%2A%2AREDACTED%2A%2A%2A')),
+        ),
+      ).called(1);
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('env_secret: ***REDACTED***')),
+        ),
+      ).called(1);
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('"env_secret": "***REDACTED***"')),
+        ),
+      ).called(1);
+
+      verifyNever(
+        () => mockLoggerApi.logInfo(any<String>(that: contains('header-value'))),
+      );
+      verifyNever(
+        () => mockLoggerApi.logInfo(any<String>(that: contains('body-value'))),
       );
     });
   });


### PR DESCRIPTION
This PR enhances the security of the networking toolkit by automatically redacting sensitive information in logs based on the `sensitiveKeys` defined in the application's current `Environment`.

### Changes:
- **`fluent_networking`**: Added `fluent_environment_api` as a dependency.
- **`NetworkingLogInterceptor`**: Now optionally accepts an `EnvironmentApi`. When provided, it fetches the current environment's `sensitiveKeys` and includes them in the redaction process for:
    - HTTP Headers
    - URI Query Parameters
    - Request and Response Bodies (including `FormData` and nested JSON structures).
- **`NetworkingModule`**: Automatically injects the registered `EnvironmentApi` into the `NetworkingLogInterceptor`.
- **Tests**: Added a comprehensive test case to `networking_log_interceptor_test.dart` to ensure that keys defined at the environment level are correctly redacted across all parts of the network request.

This change ensures that sensitive configuration values (like API keys or secrets defined in the environment) are never leaked through the networking logs, even if they are not explicitly listed in the networking configuration.

---
*PR created automatically by Jules for task [7274917301865843895](https://jules.google.com/task/7274917301865843895) started by @aosorio-avilez*