### PR TITLE
feat(environment): add support for custom developer actions in environment inspector

### DIFF
--- a/packages/fluent_environment/fluent_environment/example/lib/main.dart
+++ b/packages/fluent_environment/fluent_environment/example/lib/main.dart
@@ -15,6 +15,41 @@ void main() async {
     ),
   ]);
 
+  // Register custom environment actions
+  Fluent.get<EnvironmentApi>()
+    ..registerAction(
+      EnvironmentAction(
+        label: 'Clear Cache',
+        icon: Icons.delete_outline,
+        onTap: (context) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Cache cleared!')),
+          );
+        },
+      ),
+    )
+    ..registerAction(
+      EnvironmentAction(
+        label: 'Show Log',
+        icon: Icons.terminal,
+        onTap: (context) {
+          showDialog<void>(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('Environment Log'),
+              content: const Text('This is a simulated environment log.'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Close'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+
   runApp(const MainApp());
 }
 

--- a/packages/fluent_environment/fluent_environment/lib/fluent_environment.dart
+++ b/packages/fluent_environment/fluent_environment/lib/fluent_environment.dart
@@ -4,3 +4,4 @@ export 'package:fluent_environment_api/fluent_environment_api.dart';
 export 'package:fluent_sdk/fluent_sdk.dart';
 
 export 'src/environment_module.dart';
+export 'src/registry_extension.dart';

--- a/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/api/environment_api_impl.dart
@@ -15,6 +15,7 @@ class EnvironmentApiImpl extends EnvironmentApi {
   final Registry registry;
   final List<void Function()> _resetters = [];
   final Map<String, bool> _featureOverrides = {};
+  final List<EnvironmentAction> _actions = [];
 
   @override
   final List<Environment> availableEnvironments;
@@ -33,6 +34,15 @@ class EnvironmentApiImpl extends EnvironmentApi {
       reset();
     }
   }
+
+  @override
+  void registerAction(EnvironmentAction action) {
+    _actions.add(action);
+    _environmentNotifier.refresh();
+  }
+
+  @override
+  List<EnvironmentAction> get actions => List.unmodifiable(_actions);
 
   @override
   void registerResetService<T extends Object>() {

--- a/packages/fluent_environment/fluent_environment/lib/src/registry_extension.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/registry_extension.dart
@@ -1,0 +1,12 @@
+import 'package:fluent_environment_api/fluent_environment_api.dart';
+import 'package:fluent_sdk/fluent_sdk.dart';
+
+/// Extension methods for the [Registry] to register environment actions.
+extension RegistryExtension on Registry {
+  /// Registers a custom action to be displayed in the environment inspector.
+  void registerEnvironmentAction(EnvironmentAction action) {
+    if (isRegistered<EnvironmentApi>()) {
+      get<EnvironmentApi>().registerAction(action);
+    }
+  }
+}

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_inspector.dart
@@ -162,6 +162,71 @@ class EnvironmentInspector extends StatelessWidget {
                     ),
                     const Divider(height: 24),
                   ],
+                  if (environmentApi.actions.isNotEmpty) ...[
+                    Text(
+                      'Actions',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    GridView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 2,
+                        crossAxisSpacing: 16,
+                        mainAxisSpacing: 16,
+                        childAspectRatio: 2.5,
+                      ),
+                      itemCount: environmentApi.actions.length,
+                      itemBuilder: (context, index) {
+                        final action = environmentApi.actions[index];
+
+                        return InkWell(
+                          onTap: () {
+                            HapticFeedback.lightImpact().ignore();
+                            action.onTap(context);
+                          },
+                          borderRadius: BorderRadius.circular(8),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: colorScheme.outlineVariant,
+                              ),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            padding: const EdgeInsets.symmetric(horizontal: 8),
+                            child: Row(
+                              children: [
+                                if (action.icon != null) ...[
+                                  Icon(
+                                    action.icon,
+                                    size: 20,
+                                    color: colorScheme.primary,
+                                  ),
+                                  const SizedBox(width: 8),
+                                ],
+                                Expanded(
+                                  child: Text(
+                                    action.label,
+                                    style:
+                                        theme.textTheme.bodyMedium?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    const Divider(height: 24),
+                  ],
                   Text(
                     configValuesLabel,
                     style: theme.textTheme.titleMedium?.copyWith(

--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -210,4 +210,34 @@ void main() {
       expect(api.isFeatureEnabled('feature1'), isTrue);
     });
   });
+
+  group('Environment Actions', () {
+    test('registerAction adds action and notifies listeners', () {
+      final mockEnv = MockEnvironment();
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
+      var notified = false;
+
+      api.environmentNotifier.addListener(() {
+        notified = true;
+      });
+
+      final action = EnvironmentAction(label: 'Test', onTap: (_) {});
+      api.registerAction(action);
+
+      expect(api.actions, contains(action));
+      expect(notified, isTrue);
+    });
+
+    test('actions returns unmodifiable list', () {
+      final mockEnv = MockEnvironment();
+      final mockRegistry = MockRegistry();
+      final api = EnvironmentApiImpl(mockEnv, [mockEnv], mockRegistry);
+
+      expect(
+        () => api.actions.add(EnvironmentAction(label: 'Test', onTap: (_) {})),
+        throwsUnsupportedError,
+      );
+    });
+  });
 }

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -26,6 +26,7 @@ void main() {
     when(() => mockEnv.values).thenReturn({});
     when(() => mockApi.environmentNotifier).thenReturn(ValueNotifier(mockEnv));
     when(() => mockApi.availableEnvironments).thenReturn([mockEnv]);
+    when(() => mockApi.actions).thenReturn([]);
   });
 
   testWidgets('should display environment details', (tester) async {
@@ -246,5 +247,39 @@ void main() {
 
     // Assert
     verify(() => mockApi.setFeatureFlag('feature1', value: false)).called(1);
+  });
+
+  testWidgets('should display and trigger environment actions', (
+    tester,
+  ) async {
+    // Arrange
+    var triggered = false;
+    final action = EnvironmentAction(
+      label: 'Clear Cache',
+      icon: Icons.delete,
+      onTap: (_) => triggered = true,
+    );
+
+    when(() => mockApi.actions).thenReturn([action]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EnvironmentInspector(environmentApi: mockApi),
+        ),
+      ),
+    );
+
+    // Assert
+    expect(find.text('Actions'), findsOneWidget);
+    expect(find.text('Clear Cache'), findsOneWidget);
+    expect(find.byIcon(Icons.delete), findsOneWidget);
+
+    // Act
+    await tester.tap(find.text('Clear Cache'));
+    await tester.pump();
+
+    // Assert
+    expect(triggered, isTrue);
   });
 }

--- a/packages/fluent_environment/fluent_environment_api/lib/fluent_environment_api.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/fluent_environment_api.dart
@@ -1,3 +1,4 @@
 export 'src/environment.dart';
+export 'src/environment_action.dart';
 export 'src/environment_api.dart';
 export 'src/environment_type.dart';

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment_action.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment_action.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+
+/// A class representing a custom action that can be performed
+/// within the environment toolkit.
+class EnvironmentAction {
+  /// Creates an [EnvironmentAction].
+  const EnvironmentAction({
+    required this.label,
+    required this.onTap,
+    this.icon,
+  });
+
+  /// The text label for the action.
+  final String label;
+
+  /// The callback to execute when the action is triggered.
+  final void Function(BuildContext context) onTap;
+
+  /// An optional icon for the action.
+  final IconData? icon;
+}

--- a/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
+++ b/packages/fluent_environment/fluent_environment_api/lib/src/environment_api.dart
@@ -1,4 +1,5 @@
 import 'package:fluent_environment_api/src/environment.dart';
+import 'package:fluent_environment_api/src/environment_action.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -37,4 +38,10 @@ abstract class EnvironmentApi {
 
   /// Sets a feature flag value at runtime.
   void setFeatureFlag(String key, {required bool value});
+
+  /// Registers a custom action to be displayed in the environment inspector.
+  void registerAction(EnvironmentAction action);
+
+  /// The list of registered custom actions.
+  List<EnvironmentAction> get actions;
 }


### PR DESCRIPTION
## Description
This PR introduces a new "Environment Actions" feature to the `fluent_environment` package. This allows developers to register custom utility functions (e.g., "Clear Cache", "Toggle Debug Overlay", "Show Logs") that are rendered as interactive tiles within the Environment Inspector.

### Key Changes:
- **API Definition**: Added `EnvironmentAction` model and updated `EnvironmentApi` in `fluent_environment_api`.
- **Implementation**: Updated `EnvironmentApiImpl` to manage registered actions and updated `EnvironmentInspector` to render them in a dedicated "Actions" section.
- **Developer Experience**: Added a `Registry` extension to allow other modules to easily register environment actions during their lifecycle.
- **Example**: Updated the environment example app to demonstrate "Clear Cache" and "Show Log" actions.
- **Testing**: Added comprehensive unit tests for `EnvironmentApiImpl` and widget tests for `EnvironmentInspector`.

## Why this is useful
Developers often need quick access to certain debugging utilities or state-clearing functions while testing their apps. Instead of creating custom debug screens, they can now contribute these actions directly to the toolkit's environment inspector, keeping all development tools in one accessible place.

---
*PR created automatically by Jules for task [10487945452435450563](https://jules.google.com/task/10487945452435450563) started by @aosorio-avilez*