### PR TITLE
feat(ci): add automated tagging and pub.dev OIDC publishing workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - '*-v*' # Triggers on e.g., fluent_navigation-v1.6.9
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for pub.dev OIDC authentication
+      contents: read
+
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: 📦 Cache Pub dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            **/.dart_tool/
+          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-cache-
+
+      - name: ⚙️ Install Tools
+        run: ./.github/workflows/scripts/install-tools.sh
+
+      - name: 📦 Install Dependencies
+        run: melos bs
+
+      - name: 🔍 Resolve Target Package and Directory
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          echo "Triggered by tag: $TAG_NAME"
+          
+          # Extract package name by stripping the -v* version suffix
+          PACKAGE_NAME=$(echo "$TAG_NAME" | sed -E 's/-v[0-9]+.*//')
+          
+          # Find the package directory containing this package name
+          PACKAGE_DIR=""
+          while read -r file; do
+            if [[ "$file" == *"/example/"* ]]; then
+              continue
+            fi
+            
+            name_in_file=$(grep "^name:" "$file" | head -n1 | awk '{print $2}' | sed "s/['\"]//g")
+            if [ "$name_in_file" = "$PACKAGE_NAME" ]; then
+              PACKAGE_DIR=$(dirname "$file")
+              break
+            fi
+          done < <(find packages -name pubspec.yaml)
+          
+          if [ -z "$PACKAGE_DIR" ]; then
+            echo "Error: Package $PACKAGE_NAME not found in workspace"
+            exit 1
+          fi
+          
+          echo "Matched package: $PACKAGE_NAME at directory $PACKAGE_DIR"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+          echo "PACKAGE_DIR=$PACKAGE_DIR" >> $GITHUB_ENV
+
+      - name: ✨ Check Formatting
+        run: melos exec --scope="${{ env.PACKAGE_NAME }}" -- "dart format . --set-exit-if-changed"
+
+      - name: 🕵️ Analyze
+        run: melos exec --scope="${{ env.PACKAGE_NAME }}" -- "flutter analyze --no-pub"
+
+      - name: 🧪 Run Tests
+        run: melos exec --scope="${{ env.PACKAGE_NAME }}" --dir-exists="test" -- "flutter test --no-pub --coverage --test-randomize-ordering-seed random"
+
+      - name: 📊 Check Coverage
+        run: melos exec --scope="${{ env.PACKAGE_NAME }}" --dir-exists="test" -- "cover check --no-display-files --min-coverage 90"
+
+      - name: 🚀 Publish to pub.dev
+        run: |
+          cd ${{ env.PACKAGE_DIR }}
+          dart pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push tags and create releases
+
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch all history and tags
+
+      - name: 🏷️ Detect and Publish New Tags
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # Set up git identity
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          echo "Scanning workspace for packages..."
+          
+          # Find all pubspec.yaml files under packages/
+          find packages -name pubspec.yaml | while read -r pubspec; do
+            # Skip example folders
+            if [[ "$pubspec" == *"/example/"* ]]; then
+              continue
+            fi
+            
+            # Skip if publish_to is 'none'
+            if grep -q "publish_to:.*none" "$pubspec"; then
+              echo "Skipping non-publishable package: $pubspec"
+              continue
+            fi
+            
+            # Parse package name and version
+            pkg_name=$(grep "^name:" "$pubspec" | head -n1 | awk '{print $2}' | sed "s/['\"]//g")
+            pkg_version=$(grep "^version:" "$pubspec" | head -n1 | awk '{print $2}' | sed "s/['\"]//g")
+            
+            if [ -z "$pkg_name" ] || [ -z "$pkg_version" ]; then
+              echo "Warning: Could not parse name or version for $pubspec"
+              continue
+            fi
+            
+            TAG="${pkg_name}-v${pkg_version}"
+            
+            # Check if tag already exists in remote/local git history
+            if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "Tag $TAG already exists. Skipping."
+            else
+              echo "New version detected! Creating tag and release for $TAG..."
+              
+              # Create the tag locally
+              git tag -a "$TAG" -m "Release $TAG"
+              
+              # Push the tag using RELEASE_TOKEN if present, fallback to default token.
+              # Note: Pushing with default GITHUB_TOKEN won't trigger downstream workflows.
+              if [ -n "${{ secrets.RELEASE_TOKEN }}" ]; then
+                git push https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }} "refs/tags/$TAG"
+              else
+                echo "Warning: secrets.RELEASE_TOKEN not found. Pushing tag using GITHUB_TOKEN. (Downstream actions will NOT be triggered)"
+                git push origin "refs/tags/$TAG"
+              fi
+              
+              # Create a GitHub Release
+              gh release create "$TAG" --title "$TAG" --generate-notes
+            fi
+          done


### PR DESCRIPTION
This Pull Request introduces a fully automated release and publishing pipeline tailored for the `flutter_fluent` monorepo structure.

Historically, preparing releases, creating tags, and publishing packages to pub.dev had to be done manually for each individual package (including both the implementation packages like `fluent_logger` and public API packages like `fluent_logger_api`). 

To automate this securely, we have introduced two new GitHub Actions workflows:
1. **`release.yml`**: Triggers automatically on pushes or merges to the `main` branch. It scans the `packages/` workspace directories recursively, extracts current package names and versions from their `pubspec.yaml` files, and checks if a corresponding tag (formatted as `<package_name>-v<version>`) exists. If a new version is detected, it automatically tags the commit, pushes the tag, and creates a GitHub Release with auto-generated release notes.
2. **`publish.yml`**: Triggers when a version tag matching `*-v*` is pushed. It dynamically maps the tag to the correct package directory (handling implementation and api package splits correctly), bootstraps the Melos workspace dependencies, runs scoped validation checks (formatting, analysis, unit testing, and coverage check), and publishes that package to pub.dev using secure OpenID Connect (OIDC) authentication.

This ensures packages are published securely without needing static credentials/secrets and only after passing all code quality tests.

List which issues are fixed by this PR:
- Closes # (automated tagging and publishing feature request)

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash