### PR TITLE
fix(networking): sanitize sensitive tokens in URI userInfo and fragments

### DIFF
--- a/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/interceptors/networking_log_interceptor.dart
@@ -208,27 +208,73 @@ class NetworkingLogInterceptor extends Interceptor {
   }
 
   String _sanitizeUri(Uri uri) {
-    if (uri.queryParameters.isEmpty) return uri.toString();
-
-    Map<String, dynamic>? queryParameters;
-    final queryParametersAll = uri.queryParametersAll;
-
-    for (final key in queryParametersAll.keys) {
-      final isSensitive =
-          _sensitiveQueryParams.contains(key) ||
-          _sensitiveQueryParams.contains(key.toLowerCase());
-
-      if (isSensitive) {
-        queryParameters ??= Map<String, List<String>>.of(
-          queryParametersAll,
-        );
-        queryParameters[key] = ['***REDACTED***'];
+    String? userInfo;
+    if (uri.hasAuthority && uri.userInfo.isNotEmpty) {
+      final colonIndex = uri.userInfo.indexOf(':');
+      if (colonIndex != -1) {
+        final username = uri.userInfo.substring(0, colonIndex);
+        userInfo = '$username:***REDACTED***';
       }
     }
 
-    return queryParameters != null
-        ? uri.replace(queryParameters: queryParameters).toString()
-        : uri.toString();
+    String? fragment;
+    if (uri.hasFragment && uri.fragment.isNotEmpty) {
+      final pairs = uri.fragment.split('&');
+      var fragmentModified = false;
+      final newPairs = <String>[];
+
+      for (final pair in pairs) {
+        final parts = pair.split('=');
+        if (parts.length == 2) {
+          final key = parts[0];
+          final isSensitive =
+              _sensitiveQueryParams.contains(key) ||
+              _sensitiveQueryParams.contains(key.toLowerCase());
+
+          if (isSensitive) {
+            newPairs.add('$key=***REDACTED***');
+            fragmentModified = true;
+          } else {
+            newPairs.add(pair);
+          }
+        } else {
+          newPairs.add(pair);
+        }
+      }
+      if (fragmentModified) {
+        fragment = newPairs.join('&');
+      }
+    }
+
+    Map<String, dynamic>? queryParameters;
+    if (uri.hasQuery) {
+      final queryParametersAll = uri.queryParametersAll;
+
+      for (final key in queryParametersAll.keys) {
+        final isSensitive =
+            _sensitiveQueryParams.contains(key) ||
+            _sensitiveQueryParams.contains(key.toLowerCase());
+
+        if (isSensitive) {
+          queryParameters ??= Map<String, List<String>>.of(
+            queryParametersAll,
+          );
+          queryParameters[key] = ['***REDACTED***'];
+        }
+      }
+    }
+
+    if (userInfo != null || queryParameters != null || fragment != null) {
+      return uri
+          .replace(
+            userInfo: userInfo ?? uri.userInfo,
+            queryParameters: queryParameters ?? uri.queryParametersAll,
+            fragment: fragment ?? uri.fragment,
+          )
+          .toString();
+    }
+
+    return uri.toString();
   }
 
   dynamic _sanitizeBody(dynamic data) {

--- a/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/interceptors/networking_log_interceptor_test.dart
@@ -152,6 +152,37 @@ void main() {
       verify(() => handler.next(options)).called(1);
     });
 
+    test('onRequest should redact sensitive keys in userInfo and fragment', () {
+      final options = RequestOptions(
+        path:
+            'https://user:secret-password@api.example.com/path?query=val#access_token=secret-token&other=1',
+        method: 'GET',
+      );
+      final handler = MockRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      verify(
+        () => mockLoggerApi.logInfo(
+          any<String>(
+            that: contains(
+              'https://user:***REDACTED***@api.example.com/path?query=val#access_token=***REDACTED***&other=1',
+            ),
+          ),
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('secret-password')),
+        ),
+      );
+      verifyNever(
+        () => mockLoggerApi.logInfo(
+          any<String>(that: contains('secret-token')),
+        ),
+      );
+    });
+
     test('onRequest should redact custom sensitive query parameters', () {
       final customInterceptor = NetworkingLogInterceptor(
         logger: mockLoggerApi,


### PR DESCRIPTION
```markdown
## Description
The `NetworkingLogInterceptor` in the `fluent_networking` package previously logged full URIs without sanitizing the `userInfo` and `fragment` components. This could inadvertently expose sensitive credentials, such as passwords provided via Basic Authentication directly in the URL (e.g. `https://user:password@...`) or access tokens returned in OAuth implicit flows (e.g. `https://...?#access_token=...`).

This PR fixes the vulnerability by extending the `_sanitizeUri` method to properly redact passwords within the URI's `userInfo` and matching sensitive keys within the URI `fragment`.

## Impact
Consumer applications utilizing `fluent_networking` are now protected from inadvertently logging sensitive tokens or passwords that may be present within a request or response URI's `userInfo` and `fragment` sections.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security Fix (addresses a vulnerability or data leak)

## Testing
- [x] Added unit tests for `NetworkingLogInterceptor` to verify `userInfo` and `fragment` sanitization.
- [x] Ran `melos analyze` and `melos test` to ensure strict quality guidelines are met.
```

---
*PR created automatically by Jules for task [1957579210551131967](https://jules.google.com/task/1957579210551131967) started by @aosorio-avilez*