### PR TITLE
fix(environment): resolve global semantics overlay bug in EnvironmentBanner

### DIFF
--- a/packages/fluent_environment/fluent_environment/CHANGELOG.md
+++ b/packages/fluent_environment/fluent_environment/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+* FIX: Resolved global semantics overlay issue in `EnvironmentBanner` by restricting `Semantics` boundaries to the interactive corner of the banner instead of wrapping the entire application layout.
+
 ## 0.10.0
 
 * FEAT: Added custom environment actions section and UI grid to the inspector.

--- a/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
+++ b/packages/fluent_environment/fluent_environment/lib/src/widgets/environment_banner.dart
@@ -98,30 +98,43 @@ class EnvironmentBanner extends StatelessWidget {
           );
         }
 
-        if (enableInspector) {
+        if (!kReleaseMode || !env.isProduction || enableInspector) {
           content = Stack(
             children: [
               content,
               Positioned.fill(
                 child: Align(
                   alignment: _getAlignmentFromLocation(location),
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.translucent,
-                    onLongPress: () {
-                      unawaited(HapticFeedback.mediumImpact());
-                      unawaited(
-                        envApi.showInspector(
-                          context,
-                          configValuesLabel: configValuesLabel,
-                          noValuesLabel: noValuesLabel,
-                          navigatorKey: navigatorKey,
-                        ),
-                      );
-                    },
-                    child: const SizedBox(
-                      width: 80,
-                      height: 80,
-                    ),
+                  child: Semantics(
+                    button: enableInspector,
+                    label: 'Environment: ${env.name}',
+                    onLongPressHint: enableInspector
+                        ? 'Long press to open environment inspector'
+                        : null,
+                    excludeSemantics: true,
+                    child: enableInspector
+                        ? GestureDetector(
+                            behavior: HitTestBehavior.translucent,
+                            onLongPress: () {
+                              unawaited(HapticFeedback.mediumImpact());
+                              unawaited(
+                                envApi.showInspector(
+                                  context,
+                                  configValuesLabel: configValuesLabel,
+                                  noValuesLabel: noValuesLabel,
+                                  navigatorKey: navigatorKey,
+                                ),
+                              );
+                            },
+                            child: const SizedBox(
+                              width: 80,
+                              height: 80,
+                            ),
+                          )
+                        : const SizedBox(
+                            width: 80,
+                            height: 80,
+                          ),
                   ),
                 ),
               ),
@@ -129,14 +142,7 @@ class EnvironmentBanner extends StatelessWidget {
           );
         }
 
-        return Semantics(
-          label: 'Environment: ${env.name}',
-          container: true,
-          onLongPressHint: enableInspector
-              ? 'Long press to open environment inspector'
-              : null,
-          child: content,
-        );
+        return content;
       },
     );
   }

--- a/packages/fluent_environment/fluent_environment/pubspec.yaml
+++ b/packages/fluent_environment/fluent_environment/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_environment
 description: Package that provides a way to register your environment globally and display it.
-version: 0.10.0
+version: 0.10.1
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_environment/fluent_environment
 


### PR DESCRIPTION
This PR resolves a critical accessibility issue in the `EnvironmentBanner` widget which was wrapping the entire application layout with global semantic labels.

Previously, because the environment banner's `Semantics` widget wrapped the entire application content, screen readers (like VoiceOver or TalkBack) could interpret the entire screen as a single non-interactive environment label. This blocked users using accessibility tools from navigating or interacting with elements inside the application. Additionally, it wrongly associated the long-press gesture hint for opening the inspector with the entire screen.

To fix this:
- We removed the global `Semantics` wrapper from the root of the widget tree.
- We restricted the `Semantics` boundary to overlay exactly the 80x80 pixel area in the corner of the screen where the banner and its long-press gesture live.
- We bumped `fluent_environment` to `0.10.1` and documented the change in `CHANGELOG.md`.

These changes ensure the application remains fully accessible to all users while keeping the environment banner's accessibility support clean and accurate.

Closes #none (accessibility enhancement)

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [x] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash