### PR TITLE
feat(networking): add native download method to NetworkingApi and fix shader test conflicts

### DIFF
--- a/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/api/environment_api_impl_test.dart
@@ -96,6 +96,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(splashFactory: NoSplash.splashFactory),
           home: Scaffold(
             body: Builder(
               builder: (context) => ElevatedButton(
@@ -136,6 +137,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         navigatorKey: navigatorKey,
         home: const Scaffold(body: Text('Home')),
       ),

--- a/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
+++ b/packages/fluent_environment/fluent_environment/test/src/widgets/environment_inspector_test.dart
@@ -43,6 +43,7 @@ void main() {
     // Act
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),
@@ -89,6 +90,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),
@@ -114,6 +116,7 @@ void main() {
     // Act
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),
@@ -134,6 +137,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),
@@ -164,6 +168,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),
@@ -215,6 +220,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),
@@ -267,6 +273,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(splashFactory: NoSplash.splashFactory),
           home: Scaffold(
             body: EnvironmentInspector(environmentApi: mockApi),
           ),
@@ -297,6 +304,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: EnvironmentInspector(environmentApi: mockApi),
         ),

--- a/packages/fluent_navigation/fluent_navigation/test/src/api/navigation_api_impl_test.dart
+++ b/packages/fluent_navigation/fluent_navigation/test/src/api/navigation_api_impl_test.dart
@@ -102,6 +102,9 @@ Future<void> pumpAppRouter(WidgetTester tester) async {
 
   await tester.pumpWidget(
     MaterialApp.router(
+      theme: ThemeData(
+        splashFactory: NoSplash.splashFactory,
+      ),
       routerConfig: router,
     ),
   );

--- a/packages/fluent_navigation/fluent_navigation/test/src/navigation_module_test.dart
+++ b/packages/fluent_navigation/fluent_navigation/test/src/navigation_module_test.dart
@@ -42,6 +42,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp.router(
+        theme: ThemeData(
+          splashFactory: NoSplash.splashFactory,
+        ),
         routerConfig: router,
       ),
     );
@@ -78,6 +81,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp.router(
+        theme: ThemeData(
+          splashFactory: NoSplash.splashFactory,
+        ),
         routerConfig: router,
       ),
     );
@@ -123,6 +129,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp.router(
+        theme: ThemeData(
+          splashFactory: NoSplash.splashFactory,
+        ),
         routerConfig: router,
       ),
     );
@@ -168,6 +177,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp.router(
+        theme: ThemeData(
+          splashFactory: NoSplash.splashFactory,
+        ),
         routerConfig: router,
       ),
     );

--- a/packages/fluent_networking/fluent_networking/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* FEAT: Added `download` method to `NetworkingApi` to support downloading files directly using Dio's native download implementation.
+
 ## 0.10.0
 
 * FEAT: Added `NetworkingCurlInterceptor` to convert and log outgoing HTTP requests as ready-to-use cURL commands.

--- a/packages/fluent_networking/fluent_networking/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.11.0
 
 * FEAT: Added `download` method to `NetworkingApi` to support downloading files directly using Dio's native download implementation.
 

--- a/packages/fluent_networking/fluent_networking/lib/fluent_networking.dart
+++ b/packages/fluent_networking/fluent_networking/lib/fluent_networking.dart
@@ -5,6 +5,7 @@ export 'package:dio/dio.dart'
         FormData,
         MultipartFile,
         Options,
+        ProgressCallback,
         RequestInterceptorHandler,
         RequestOptions,
         Response,

--- a/packages/fluent_networking/fluent_networking/lib/src/networking_api_impl.dart
+++ b/packages/fluent_networking/fluent_networking/lib/src/networking_api_impl.dart
@@ -91,6 +91,25 @@ class NetworkingApiImpl extends NetworkingApi {
     );
   }
 
+  @override
+  Future<ResponseResult<T>> download<T>(
+    String url,
+    dynamic savePath, {
+    ProgressCallback? onReceiveProgress,
+    Options? options,
+    RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
+  }) {
+    return _execute(
+      () => _httpClient.download(
+        url,
+        savePath,
+        onReceiveProgress: onReceiveProgress,
+        options: _mergeOptions(options, retryConfig, cacheConfig),
+      ),
+    );
+  }
+
   Options _mergeOptions(
     Options? options,
     RetryConfig? retryConfig,

--- a/packages/fluent_networking/fluent_networking/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_networking
 description: Package that provides a simple way to make http requests
-version: 0.10.0
+version: 0.11.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_networking/fluent_networking
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   fluent_sdk: ^0.8.0
-  fluent_networking_api: ^0.4.0
+  fluent_networking_api: ^0.5.0
   fluent_logger_api: ^0.0.4
   dio: ^5.9.1
   equatable: ^2.0.8

--- a/packages/fluent_networking/fluent_networking/test/src/networking_api_impl_test.dart
+++ b/packages/fluent_networking/fluent_networking/test/src/networking_api_impl_test.dart
@@ -270,5 +270,94 @@ void main() {
         expect((result as Failure).error.code, 500);
       });
     });
+
+    group('DOWNLOAD', () {
+      test('should return Success when status is 200', () async {
+        when(
+          () => mockDio.download(
+            any<String>(),
+            any<dynamic>(),
+            onReceiveProgress: any<ProgressCallback>(
+              named: 'onReceiveProgress',
+            ),
+            options: any<Options>(named: 'options'),
+          ),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/'),
+            statusCode: 200,
+          ),
+        );
+
+        final result = await networkingApi.download<void>('/', 'path/to/save');
+
+        expect(result, isA<Success<void>>());
+      });
+
+      test('should pass onReceiveProgress to Dio.download', () async {
+        var progressCalled = false;
+        void testProgress(int count, int total) {
+          progressCalled = true;
+        }
+
+        when(
+          () => mockDio.download(
+            any<String>(),
+            any<dynamic>(),
+            onReceiveProgress: any<ProgressCallback>(
+              named: 'onReceiveProgress',
+            ),
+            options: any<Options>(named: 'options'),
+          ),
+        ).thenAnswer(
+          (invocation) async {
+            final callback =
+                invocation.namedArguments[#onReceiveProgress]
+                    as ProgressCallback?;
+            callback?.call(50, 100);
+            return Response(
+              requestOptions: RequestOptions(path: '/'),
+              statusCode: 200,
+            );
+          },
+        );
+
+        await networkingApi.download<void>(
+          '/',
+          'path/to/save',
+          onReceiveProgress: testProgress,
+        );
+
+        expect(progressCalled, isTrue);
+      });
+
+      test('should return Failure when Dio throws', () async {
+        when(
+          () => mockDio.download(
+            any<String>(),
+            any<dynamic>(),
+            onReceiveProgress: any<ProgressCallback>(
+              named: 'onReceiveProgress',
+            ),
+            options: any<Options>(named: 'options'),
+          ),
+        ).thenThrow(
+          DioException(
+            requestOptions: RequestOptions(path: '/'),
+            response: Response(
+              requestOptions: RequestOptions(path: '/'),
+              statusCode: 500,
+              data: {'message': 'Download Failed'},
+            ),
+          ),
+        );
+
+        final result = await networkingApi.download<void>('/', 'path/to/save');
+
+        expect(result, isA<Failure<void>>());
+        expect((result as Failure).error.code, 500);
+        expect(result.error.message, 'Download Failed');
+      });
+    });
   });
 }

--- a/packages/fluent_networking/fluent_networking_api/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* FEAT: Added `download` method signature to `NetworkingApi` contract with optional `ProgressCallback` support.
+
 ## 0.4.0
 
 * **FEAT**: Add caching support to networking API.

--- a/packages/fluent_networking/fluent_networking_api/CHANGELOG.md
+++ b/packages/fluent_networking/fluent_networking_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.5.0
 
 * FEAT: Added `download` method signature to `NetworkingApi` contract with optional `ProgressCallback` support.
 

--- a/packages/fluent_networking/fluent_networking_api/lib/src/networking_api.dart
+++ b/packages/fluent_networking/fluent_networking_api/lib/src/networking_api.dart
@@ -53,4 +53,15 @@ abstract class NetworkingApi {
     RetryConfig? retryConfig,
     CacheConfig? cacheConfig,
   });
+
+  /// Downloads a file or binary from [url] and saves it to [savePath].
+  /// Optionally, [onReceiveProgress] can be provided to monitor progress.
+  Future<ResponseResult<T>> download<T>(
+    String url,
+    dynamic savePath, {
+    ProgressCallback? onReceiveProgress,
+    Options? options,
+    RetryConfig? retryConfig,
+    CacheConfig? cacheConfig,
+  });
 }

--- a/packages/fluent_networking/fluent_networking_api/pubspec.yaml
+++ b/packages/fluent_networking/fluent_networking_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_networking_api
 description: A common interface for the fluent_networking package.
-version: 0.4.0
+version: 0.5.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_networking/fluent_networking_api
 


### PR DESCRIPTION
This PR introduces the `download` method to the `NetworkingApi` contract (`fluent_networking_api`) and implements it in the concrete client (`fluent_networking`) using Dio's native `download` functionality. Additionally, it fixes a pre-existing shader compilation issue during tests in `fluent_environment` and `fluent_navigation`.

### Description

#### 1. Download Feature (`fluent_networking` & `fluent_networking_api`)
We have added support for downloading files (such as PDFs or other binary documents) directly to local storage:
- **Contract Signature**: Added the `download<T>` method to the abstract `NetworkingApi` class, accepting the remote `url`, local `savePath`, and optional arguments like `onReceiveProgress`, `options`, `retryConfig`, and `cacheConfig`.
- **Implementation**: Implemented the method using the native `_httpClient.download` from `dio`.
- **Exports**: Exported `ProgressCallback` from the main barrel file of `fluent_networking` so consumers don't have to manually import `dio` to declare download progress callbacks.
- **Tests**: Wrote new unit tests confirming successful downloads, error handling, and progress monitoring.

#### 2. Shader Test Fixes (`fluent_environment` & `fluent_navigation`)
We resolved a version mismatch error (`Unsupported runtime stages format version`) that caused widget tests to crash under different environment versions of Flutter (global vs. FVM local) when checking ink splashes:
- **Fix**: Disabled ink splashes (`splashFactory: NoSplash.splashFactory`) in `MaterialApp` and `MaterialApp.router` configurations within all the affected widget tests.

### Impact on Consumer Applications
This change allows you to download files in a simple, standardized way without needing to interact with the underlying HTTP package details directly:

```dart
final result = await Fluent.get<NetworkingApi>().download(
  'https://example.com/document.pdf',
  '/local/path/to/document.pdf',
  onReceiveProgress: (count, total) {
    print('Progress: $count / $total bytes');
  },
);

if (result is Success) {
  print('Download completed successfully!');
}
```

### What type of change?
- [x] ✨ New feature (change which adds functionality)
- [x]  🛠️ Bug fix (change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Trash