### PR TITLE
feat(navigation): add popUntil method to NavigationApi

### DIFF
--- a/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.0
+
+* **Feature**: Added `popUntil` method to `NavigationApiImpl` to allow popping routes until reaching a specific route name.
+* **Chore**: Updated `fluent_navigation_api` dependency constraint to `^1.3.0`.
+
 ## 1.9.0
 
 * CHORE: Updated `fluent_sdk` dependency to `^0.8.0`.

--- a/packages/fluent_navigation/fluent_navigation/README.md
+++ b/packages/fluent_navigation/fluent_navigation/README.md
@@ -6,7 +6,7 @@ Package that provides a simple way to navigate within your app
 ### Add dependencies
 
 ```yaml
-fluent_navigation: ^1.9.0
+fluent_navigation: ^1.10.0
 ```
 
 ### Create pages

--- a/packages/fluent_navigation/fluent_navigation/example/lib/page_d.dart
+++ b/packages/fluent_navigation/fluent_navigation/example/lib/page_d.dart
@@ -15,6 +15,10 @@ class PageD extends StatelessWidget {
             onPressed: () => Fluent.get<NavigationApi>().pop(),
             child: const Text("Go back"),
           ),
+          ElevatedButton(
+            onPressed: () => Fluent.get<NavigationApi>().popUntil('b'),
+            child: const Text("Pop until b"),
+          ),
         ],
       ),
     );

--- a/packages/fluent_navigation/fluent_navigation/lib/src/api/navigation_api_impl.dart
+++ b/packages/fluent_navigation/fluent_navigation/lib/src/api/navigation_api_impl.dart
@@ -72,4 +72,13 @@ class NavigationApiImpl extends NavigationApi {
       _router.pop(result);
     }
   }
+
+  @override
+  void popUntil(String routeName) {
+    _navigatorKey.currentState?.popUntil((route) {
+      return route.settings.name == routeName ||
+          route.settings.name == '/$routeName' ||
+          route.isFirst;
+    });
+  }
 }

--- a/packages/fluent_navigation/fluent_navigation/pubspec.yaml
+++ b/packages/fluent_navigation/fluent_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_navigation
 description: Package that provides a simple way to navigate within your app
-version: 1.9.0
+version: 1.10.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_navigation/fluent_navigation
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   fluent_sdk: ^0.8.0
-  fluent_navigation_api: ^1.2.0
+  fluent_navigation_api: ^1.3.0
   go_router: ^17.0.1
   collection: ^1.19.1
 

--- a/packages/fluent_navigation/fluent_navigation/test/src/api/navigation_api_impl_test.dart
+++ b/packages/fluent_navigation/fluent_navigation/test/src/api/navigation_api_impl_test.dart
@@ -95,6 +95,23 @@ void main() {
     expect(find.byKey(const Key('firstPage')), findsOneWidget);
     expect(find.text('Hello from first page'), findsOneWidget);
   });
+
+  testWidgets('verify popUntil', (tester) async {
+    await pumpAppRouter(tester);
+
+    await tester.tap(find.byKey(const Key('pushButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('pushThirdButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('thirdPage')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('popUntilButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('firstPage')), findsOneWidget);
+  });
 }
 
 Future<void> pumpAppRouter(WidgetTester tester) async {
@@ -162,12 +179,39 @@ void mockRoutes() {
       builder: (context, state) {
         return Scaffold(
           key: const Key('secondPage'),
+          body: Column(
+            children: [
+              ElevatedButton(
+                key: const Key('popButton'),
+                onPressed: () {
+                  Fluent.get<NavigationApi>().pop(true);
+                },
+                child: const Text('Go back to previous route'),
+              ),
+              ElevatedButton(
+                key: const Key('pushThirdButton'),
+                onPressed: () async {
+                  await Fluent.get<NavigationApi>().pushTo<void>('third');
+                },
+                child: const Text('Go to third route'),
+              ),
+            ],
+          ),
+        );
+      },
+    ),
+    GoRoute(
+      name: 'third',
+      path: '/third',
+      builder: (context, state) {
+        return Scaffold(
+          key: const Key('thirdPage'),
           body: ElevatedButton(
-            key: const Key('popButton'),
+            key: const Key('popUntilButton'),
             onPressed: () {
-              Fluent.get<NavigationApi>().pop(true);
+              Fluent.get<NavigationApi>().popUntil('first');
             },
-            child: const Text('Go back to previous route'),
+            child: const Text('Pop until first route'),
           ),
         );
       },

--- a/packages/fluent_navigation/fluent_navigation_api/CHANGELOG.md
+++ b/packages/fluent_navigation/fluent_navigation_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+*   Added `popUntil` method to `NavigationApi` interface.
+
 ## 1.2.0
 
 *   Added `replaceWith` method to `NavigationApi` interface.

--- a/packages/fluent_navigation/fluent_navigation_api/lib/src/navigation_api.dart
+++ b/packages/fluent_navigation/fluent_navigation_api/lib/src/navigation_api.dart
@@ -40,6 +40,9 @@ abstract class NavigationApi {
   /// And pass it an optional result.
   void pop<T>([T? result]);
 
+  /// Pop the routes until the given route name.
+  void popUntil(String routeName);
+
   /// Get the router configuration
   RouterConfig<Object> get router;
 

--- a/packages/fluent_navigation/fluent_navigation_api/pubspec.yaml
+++ b/packages/fluent_navigation/fluent_navigation_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_navigation_api
 description: A common interface for the fluent_navigation package.
-version: 1.2.0
+version: 1.3.0
 resolution: workspace
 repository: https://github.com/aosorio-avilez/flutter_fluent/tree/main/packages/fluent_navigation/fluent_navigation_api
 


### PR DESCRIPTION
This PR introduces a new `popUntil` method to the `fluent_navigation` and `fluent_navigation_api` packages. 

### What does this change?

- Adds `popUntil(String routeName)` to the public `NavigationApi` interface to enable backward navigation through multiple screens until a specific target route is reached.
- Implements `popUntil` using Flutter's underlying `NavigatorState` while safely handling root route boundary checks to prevent unexpected screen stack crashes.
- Adds comprehensive unit test coverage verifying multi-route stack popping.
- Updates the example application to demonstrate `popUntil` usage.
- Prepares release versions for `fluent_navigation_api` (`v1.3.0`) and `fluent_navigation` (`v1.10.0`).

### Impact on Consumer Applications

Consumer applications can now easily navigate back to a specific previous screen in multi-step workflows or wizards (for example, popping back to a main dashboard or initial step) with a single, clean API call.

Fixes #

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash